### PR TITLE
print labels of in- and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,46 @@ Use `fan2go detect` to print a list of all usable devices:
 ```shell
 > fan2go detect
 Detected Devices:
-acpitz
-  temp1_input (1): 27800
-  temp2_input (2): 29800
 nvme
-  temp1_input (1): 52850
-  temp2_input (2): 52850
-  temp3_input (3): 64850
-coretemp
-  temp1_input (1): 59000
-  temp2_input (2): 57000
-  temp3_input (3): 52000
-  temp4_input (4): 56000
-  temp5_input (5): 50000
-it8620
-  pwm1 (1): RPM: 0 PWM: 70 Auto: false
-  pwm2 (2): RPM: 0 PWM: 70 Auto: false
-  pwm3 (3): RPM: 709 PWM: 106 Auto: false
-  pwm4 (4): RPM: 627 PWM: 94 Auto: false
-  pwm5 (5): RPM: 684 PWM: 100 Auto: false
-  temp1_input (1): 29000
-  temp2_input (2): 32000
-  temp3_input (3): 49000
-  temp4_input (4): 29000
-  temp5_input (5): 46000
-  temp6_input (6): 46000
-nouveau
-  pwm1 (1): RPM: 1560 PWM: 31 Auto: false
-  temp1_input (1): 33000
+  1: Composite (temp1_input): 51850
+  2: Sensor 1 (temp2_input): 51850
+  3: Sensor 2 (temp3_input): 52850
+nvme
+  1: Composite (temp1_input): 52850
+  2: Sensor 1 (temp2_input): 52850
+  3: Sensor 2 (temp3_input): 45850
+nvme
+  1: Composite (temp1_input): 52850
+  2: Sensor 1 (temp2_input): 52850
+  3: Sensor 2 (temp3_input): 53850
+nct6798
+  1: hwmon5 (pwm1): RPM: 0 PWM: 142 Auto: false
+  2: hwmon5 (pwm2): RPM: 994 PWM: 68 Auto: false
+  3: hwmon5 (pwm3): RPM: 579 PWM: 96 Auto: false
+  4: hwmon5 (pwm4): RPM: 345 PWM: 58 Auto: false
+  5: hwmon5 (pwm5): RPM: 343 PWM: 57 Auto: false
+  6: hwmon5 (pwm6): RPM: 0 PWM: 255 Auto: false
+  7: hwmon5 (pwm7): RPM: 0 PWM: 255 Auto: false
+  1: SYSTIN (temp1_input): 43000
+  2: CPUTIN (temp2_input): 55500
+  3: AUXTIN0 (temp3_input): 22000
+  4: AUXTIN1 (temp4_input): 127000
+  5: AUXTIN2 (temp5_input): 100000
+  6: AUXTIN3 (temp6_input): 32000
+  7: PECI Agent 0 Calibration (temp7_input): 56500
+  8: PCH_CHIP_CPU_MAX_TEMP (temp8_input): 0
+  9: PCH_CHIP_TEMP (temp9_input): 0
+k10temp
+  1: Tctl (temp1_input): 75875
+  2: Tdie (temp2_input): 75875
+  3: Tccd1 (temp3_input): 69250
+iwlwifi_1
+  1: hwmon8 (temp1_input): 41000
+amdgpu
+  1: hwmon9 (pwm1): RPM: 561 PWM: 43 Auto: false
+  1: edge (temp1_input): 56000
+  2: junction (temp2_input): 59000
+  3: mem (temp3_input): 56000
 ```
 
 Then configure fan2go by creating a YAML configuration file in **one** of the following locations:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,12 +57,12 @@ var detectCmd = &cobra.Command{
 				pwm := internal.GetPwm(fan)
 				rpm := internal.GetRpm(fan)
 				isAuto, _ := internal.IsPwmAuto(controller.Path)
-				fmt.Printf("  %s (%d): RPM: %d PWM: %d Auto: %v\n", fan.Name, fan.Index, rpm, pwm, isAuto)
+				fmt.Printf("  %d: %s (%s): RPM: %d PWM: %d Auto: %v\n", fan.Index, fan.Label, fan.Name, rpm, pwm, isAuto)
 			}
 
 			for _, sensor := range controller.Sensors {
 				value, _ := util.ReadIntFromFile(sensor.Input)
-				fmt.Printf("  %s (%d): %d\n", sensor.Name, sensor.Index, value)
+				fmt.Printf("  %d: %s (%s): %d\n", sensor.Index, sensor.Label, sensor.Name, value)
 			}
 		}
 	},

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -427,7 +427,7 @@ func calculateTargetSpeed(fan *Fan) int {
 	return int(ratio * 255)
 }
 
-// Finds controllers and fans
+// FindControllers Finds controllers and fans
 func FindControllers() (controllers []*Controller, err error) {
 	hwmonDevices := util.FindHwmonDevicePaths()
 	i2cDevices := util.FindI2cDevicePaths()
@@ -476,6 +476,8 @@ func createFans(devicePath string) []*Fan {
 	for idx, output := range outputs {
 		_, file := filepath.Split(output)
 
+		label := util.GetLabel(devicePath, output)
+
 		index, err := strconv.Atoi(file[len(file)-1:])
 		if err != nil {
 			log.Fatal(err)
@@ -483,6 +485,7 @@ func createFans(devicePath string) []*Fan {
 
 		fan := &Fan{
 			Name:         file,
+			Label:        label,
 			Index:        index,
 			PwmOutput:    output,
 			RpmInput:     inputs[idx],
@@ -514,6 +517,7 @@ func createSensors(devicePath string) []*Sensor {
 
 	for _, input := range inputs {
 		_, file := filepath.Split(input)
+		label := util.GetLabel(devicePath, file)
 
 		index, err := strconv.Atoi(string(file[4]))
 		if err != nil {
@@ -522,6 +526,7 @@ func createSensors(devicePath string) []*Sensor {
 
 		sensors = append(sensors, &Sensor{
 			Name:  file,
+			Label: label,
 			Index: index,
 			Input: input,
 		})
@@ -530,7 +535,7 @@ func createSensors(devicePath string) []*Sensor {
 	return sensors
 }
 
-// checks if the given output is in auto mode
+// IsPwmAuto checks if the given output is in auto mode
 func IsPwmAuto(outputPath string) (bool, error) {
 	pwmEnabledFilePath := outputPath + "_enable"
 
@@ -587,7 +592,7 @@ func getMinPwmValue(fan *Fan) (result int) {
 	return MinPwmValue
 }
 
-// get the pwm speed of a fan (0..255)
+// GetPwm get the pwm speed of a fan (0..255)
 func GetPwm(fan *Fan) int {
 	value, err := util.ReadIntFromFile(fan.PwmOutput)
 	if err != nil {
@@ -648,7 +653,7 @@ func setPwm(fan *Fan, pwm int) (err error) {
 	return err
 }
 
-// get the rpm value of a fan
+// GetRpm get the rpm value of a fan
 func GetRpm(fan *Fan) int {
 	value, err := util.ReadIntFromFile(fan.RpmInput)
 	if err != nil {

--- a/internal/data.go
+++ b/internal/data.go
@@ -16,6 +16,7 @@ type Controller struct {
 
 type Fan struct {
 	Name               string                        `json:"name"`
+	Label              string                        `json:"label"`
 	Index              int                           `json:"index"`
 	RpmInput           string                        `json:"rpminput"`
 	RpmMovingAvg       float64                       `json:"rpmmovingavg"`
@@ -30,6 +31,7 @@ type Fan struct {
 
 type Sensor struct {
 	Name      string        `json:"name"`
+	Label     string        `json:"label"`
 	Index     int           `json:"index"`
 	Input     string        `json:"string"`
 	Config    *SensorConfig `json:"config"`

--- a/internal/persistence.go
+++ b/internal/persistence.go
@@ -22,7 +22,7 @@ func OpenPersistence(dbPath string) *bolt.DB {
 	return db
 }
 
-// saves the fan curve data of the given fan
+// SaveFanPwmData saves the fan curve data of the given fan
 func SaveFanPwmData(db *bolt.DB, fan *Fan) (err error) {
 	key := fan.PwmOutput
 
@@ -52,7 +52,7 @@ func SaveFanPwmData(db *bolt.DB, fan *Fan) (err error) {
 	})
 }
 
-// loads the fan curve data and attaches it to the given fan
+// LoadFanPwmData loads the fan curve data and attaches it to the given fan
 func LoadFanPwmData(db *bolt.DB, fan *Fan) error {
 	key := fan.PwmOutput
 

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -22,7 +22,7 @@ func ReadIntFromFile(path string) (value int, err error) {
 	return strconv.Atoi(text)
 }
 
-// write a single integer to a file.go path
+// WriteIntToFile write a single integer to a file.go path
 func WriteIntToFile(value int, path string) (err error) {
 	f, err := os.OpenFile(path, os.O_SYNC|os.O_WRONLY, 644)
 	if err != nil {
@@ -36,7 +36,7 @@ func WriteIntToFile(value int, path string) (err error) {
 	return err
 }
 
-// finds all files in a given directory, matching the given regex
+// FindFilesMatching finds all files in a given directory, matching the given regex
 func FindFilesMatching(path string, expr string) []string {
 	r, err := regexp.Compile(expr)
 	if err != nil {

--- a/internal/util/hwmon.go
+++ b/internal/util/hwmon.go
@@ -18,7 +18,7 @@ func GetDeviceName(devicePath string) string {
 	return strings.TrimSpace(name)
 }
 
-// GetLabel read the name of a device
+// GetLabel read the label of a in/output of a device
 func GetLabel(devicePath string, input string) string {
 	labelPath := strings.TrimSuffix(devicePath+"/"+input, "input") + "label"
 

--- a/internal/util/hwmon.go
+++ b/internal/util/hwmon.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// read the name of a device
+// GetDeviceName read the name of a device
 func GetDeviceName(devicePath string) string {
 	namePath := devicePath + "/name"
 	content, _ := ioutil.ReadFile(namePath)
@@ -18,14 +18,26 @@ func GetDeviceName(devicePath string) string {
 	return strings.TrimSpace(name)
 }
 
-// read the modalias of a device
+// GetLabel read the name of a device
+func GetLabel(devicePath string, input string) string {
+	labelPath := strings.TrimSuffix(devicePath+"/"+input, "input") + "label"
+
+	content, _ := ioutil.ReadFile(labelPath)
+	label := string(content)
+	if len(label) <= 0 {
+		_, label = filepath.Split(devicePath)
+	}
+	return strings.TrimSpace(label)
+}
+
+// GetDeviceModalias read the modalias of a device
 func GetDeviceModalias(devicePath string) string {
 	modaliasPath := devicePath + "/device/modalias"
 	content, _ := ioutil.ReadFile(modaliasPath)
 	return strings.TrimSpace(string(content))
 }
 
-// read the type of a device
+// GetDeviceType read the type of a device
 func GetDeviceType(devicePath string) string {
 	modaliasPath := devicePath + "/device/type"
 	content, _ := ioutil.ReadFile(modaliasPath)


### PR DESCRIPTION
fixes #23 

Labels of sensors and fans are now printed when running `fan2go detect`