### PR TITLE
Feature/#28 spindown improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ sudo mkdir /etc/fan2go
 ```yaml
 # The path of the database file.
 dbPath: "/etc/fan2go/fan2go.db"
+# Allow the fan initialization sequence to run in parallel for all configured fans
+runFanInitializationInParallel: false
 # The rate to poll temperature sensors at.
 tempSensorPollingRate: 200ms
 # The number of sensor items to keep in a rolling window array.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -213,6 +213,7 @@ func validateConfig() {
 
 func setDefaultValues() {
 	viper.SetDefault("dbpath", "/etc/fan2go/fan2go.db")
+	viper.SetDefault("RunFanInitializationInParallel", false)
 	viper.SetDefault("TempSensorPollingRate", 200*time.Millisecond)
 	viper.SetDefault("TempRollingWindowSize", 50)
 	viper.SetDefault("RpmPollingRate", 1*time.Second)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -214,6 +214,7 @@ func validateConfig() {
 func setDefaultValues() {
 	viper.SetDefault("dbpath", "/etc/fan2go/fan2go.db")
 	viper.SetDefault("RunFanInitializationInParallel", true)
+	viper.SetDefault("MaxRpmDiffForSettledFan", 10.0)
 	viper.SetDefault("TempSensorPollingRate", 200*time.Millisecond)
 	viper.SetDefault("TempRollingWindowSize", 50)
 	viper.SetDefault("RpmPollingRate", 1*time.Second)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -213,7 +213,7 @@ func validateConfig() {
 
 func setDefaultValues() {
 	viper.SetDefault("dbpath", "/etc/fan2go/fan2go.db")
-	viper.SetDefault("RunFanInitializationInParallel", false)
+	viper.SetDefault("RunFanInitializationInParallel", true)
 	viper.SetDefault("TempSensorPollingRate", 200*time.Millisecond)
 	viper.SetDefault("TempRollingWindowSize", 50)
 	viper.SetDefault("RpmPollingRate", 1*time.Second)

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -1,5 +1,7 @@
 # The path of the database file.
 dbPath: "/etc/fan2go/fan2go.db"
+# Allow the fan initialization sequence to run in parallel for all configured fans
+runFanInitializationInParallel: false
 # The rate to poll temperature sensors at.
 tempSensorPollingRate: 200ms
 # The number of sensor items to keep in a rolling window array.

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -2,6 +2,8 @@
 dbPath: "/etc/fan2go/fan2go.db"
 # Allow the fan initialization sequence to run in parallel for all configured fans
 runFanInitializationInParallel: false
+# Maximal RPM speed difference between 10 fan speed measurements to consider it "settled"
+maxRpmDiffForSettledFan: 10.0
 # The rate to poll temperature sensors at.
 tempSensorPollingRate: 200ms
 # The number of sensor items to keep in a rolling window array.

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -100,6 +100,10 @@ func Run(verbose bool) {
 					tick := time.Tick(CurrentConfig.ControllerAdjustmentTickRate)
 					return fanController(ctx, db, fan, tick)
 				}, func(err error) {
+					if err != nil {
+						log.Printf("Something went wrong: %v", err)
+					}
+
 					log.Printf("Trying to restore fan settings for %s...", fan.Config.Id)
 
 					// try to reset the pwm_enabled value
@@ -137,7 +141,7 @@ func Run(verbose bool) {
 	}
 
 	if err := g.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -229,8 +229,8 @@ func measureRpm(fan *Fan) {
 	fan.RpmMovingAvg = updateSimpleMovingAvg(fan.RpmMovingAvg, CurrentConfig.RpmRollingWindowSize, float64(rpm))
 
 	pwmRpmMap := fan.FanCurveData
-	pointWindow, ok := (*pwmRpmMap)[pwm]
-	if !ok {
+	pointWindow, exists := (*pwmRpmMap)[pwm]
+	if !exists {
 		// create rolling window for current pwm value
 		pointWindow = rolling.NewPointPolicy(rolling.NewWindow(CurrentConfig.RpmRollingWindowSize))
 		(*pwmRpmMap)[pwm] = pointWindow
@@ -239,9 +239,9 @@ func measureRpm(fan *Fan) {
 }
 
 // GetPwmBoundaries calculates the startPwm and maxPwm values for a fan based on its fan curve data
-func GetPwmBoundaries(fan *Fan) (int, int) {
-	startPwm := 255
-	maxPwm := 255
+func GetPwmBoundaries(fan *Fan) (startPwm int, maxPwm int) {
+	startPwm = 255
+	maxPwm = 255
 	pwmRpmMap := fan.FanCurveData
 
 	// get pwm keys that we have data for
@@ -552,9 +552,7 @@ func FindControllers() (controllers []*Controller, err error) {
 }
 
 // creates fan objects for the given device path
-func createFans(devicePath string) []*Fan {
-	var fans []*Fan
-
+func createFans(devicePath string) (fans []*Fan) {
 	inputs := util.FindFilesMatching(devicePath, "^fan[1-9]_input$")
 	outputs := util.FindFilesMatching(devicePath, "^pwm[1-9]$")
 
@@ -595,9 +593,7 @@ func createFans(devicePath string) []*Fan {
 }
 
 // creates sensor objects for the given device path
-func createSensors(devicePath string) []*Sensor {
-	var sensors []*Sensor
-
+func createSensors(devicePath string) (sensors []*Sensor) {
 	inputs := util.FindFilesMatching(devicePath, "^temp[1-9]_input$")
 
 	for _, input := range inputs {
@@ -678,10 +674,10 @@ func getMinPwmValue(fan *Fan) (result int) {
 }
 
 // GetPwm get the pwm speed of a fan (0..255)
-func GetPwm(fan *Fan) int {
+func GetPwm(fan *Fan) (value int) {
 	value, err := util.ReadIntFromFile(fan.PwmOutput)
 	if err != nil {
-		return MinPwmValue
+		value = MinPwmValue
 	}
 	return value
 }
@@ -774,10 +770,10 @@ func setPwm(fan *Fan, target int) (err error) {
 }
 
 // GetRpm get the rpm value of a fan
-func GetRpm(fan *Fan) int {
+func GetRpm(fan *Fan) (value int) {
 	value, err := util.ReadIntFromFile(fan.RpmInput)
 	if err != nil {
-		return 0
+		value = -1
 	}
 	return value
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -14,6 +14,7 @@ type Configuration struct {
 	RpmRollingWindowSize           int
 	Sensors                        []SensorConfig
 	Fans                           []FanConfig
+	MaxRpmDiffForSettledFan        float64
 }
 
 type SensorConfig struct {

--- a/internal/config.go
+++ b/internal/config.go
@@ -5,14 +5,15 @@ import (
 )
 
 type Configuration struct {
-	DbPath                       string
-	TempSensorPollingRate        time.Duration
-	RpmPollingRate               time.Duration
-	ControllerAdjustmentTickRate time.Duration
-	TempRollingWindowSize        int
-	RpmRollingWindowSize         int
-	Sensors                      []SensorConfig
-	Fans                         []FanConfig
+	DbPath                         string
+	RunFanInitializationInParallel bool
+	TempSensorPollingRate          time.Duration
+	RpmPollingRate                 time.Duration
+	ControllerAdjustmentTickRate   time.Duration
+	TempRollingWindowSize          int
+	RpmRollingWindowSize           int
+	Sensors                        []SensorConfig
+	Fans                           []FanConfig
 }
 
 type SensorConfig struct {


### PR DESCRIPTION
contributes to #28

This PR adds
* a config option `runFanInitializationInParallel` to prevent fans from beeing initialized all at the same time, and initialize them one after another instead
* a "settle" algorithm to make sure a fan has reached full stop before continuing with the initialization process
* a config option `maxRpmDiffForSettledFan` to specify the max difference that should still be considered "settled"
* more and better logging
* some refactoring