### PR TITLE
internal(curves): add curve based on delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,21 @@ system run `fan2go detect`, which will print a list of devices exposed by the hw
 ```shell
 > fan2go detect
 nct6798
- Fans      Index   Label    RPM    PWM   Auto   
-           1       hwmon4   0      153   false  
-           2       hwmon4   1223   104   false  
-           3       hwmon4   677    107   false  
- Sensors   Index   Label    Value   
-           1       SYSTIN   41000   
-           2       CPUTIN   64000   
- 
+ Fans      Index   Label    RPM    PWM   Auto
+           1       hwmon4   0      153   false
+           2       hwmon4   1223   104   false
+           3       hwmon4   677    107   false
+ Sensors   Index   Label    Value
+           1       SYSTIN   41000
+           2       CPUTIN   64000
+
 amdgpu-pci-0031
- Fans      Index   Label    RPM   PWM   Auto   
-           1       hwmon8   561   43    false  
- Sensors   Index   Label      Value  
-           1       edge       58000  
-           2       junction   61000  
-           3       mem        56000  
+ Fans      Index   Label    RPM   PWM   Auto
+           1       hwmon8   561   43    false
+ Sensors   Index   Label      Value
+           1       edge       58000
+           2       junction   61000
+           3       mem        56000
 ```
 
 To use detected devices in your configuration, use the `hwmon` fan type:
@@ -186,7 +186,7 @@ curves:
       sensor: cpu_package
       # Steps to define a section-wise defined speed curve function.
       steps:
-        # Sensor value -> Speed (in percent)
+        # Sensor value -> Speed (in pwm)
         - 40: 0
         - 50: 50
         - 80: 255
@@ -200,7 +200,7 @@ To create more complex curves you can combine exising curves using a curve of ty
 curves:
   - id: case_avg_curve
     function:
-      # Type of aggregation function to use, on of: minimum | maximum | average
+      # Type of aggregation function to use, one of: minimum | maximum | average | delta
       type: average
       # A list of curve IDs to use
       curves:
@@ -240,17 +240,17 @@ a look at this measurement using the following command:
 ```shell
 > sudo fan2go curve
 nct6798 -> pwm1
-                  
- Start PWM   0    
- Max PWM     255  
+
+ Start PWM   0
+ Max PWM     255
 
 No fan curve data yet...
 
 
 nct6798 -> pwm2
-                  
- Start PWM   0    
- Max PWM     194  
+
+ Start PWM   0
+ Max PWM     194
 
  1994 ┤                                                                          ╭────────────────────────
  1900 ┤                                                                       ╭──╯

--- a/internal/configuration/curves.go
+++ b/internal/configuration/curves.go
@@ -15,6 +15,7 @@ type LinearCurveConfig struct {
 
 const (
 	FunctionAverage = "average"
+	FunctionDelta   = "delta"
 	FunctionMinimum = "minimum"
 	FunctionMaximum = "maximum"
 )

--- a/internal/curves/curve.go
+++ b/internal/curves/curve.go
@@ -106,6 +106,15 @@ func (c functionSpeedCurve) Evaluate() (value int, err error) {
 	}
 
 	switch c.function {
+    case configuration.FunctionDelta:
+		var dmax = float64(values[0])
+		var dmin = float64(values[0])
+		for _, v := range values {
+			dmin = math.Min(dmin, float64(v))
+			dmax = math.Max(dmax, float64(v))
+		}
+		delta := dmax - dmin
+		return int(delta), nil
 	case configuration.FunctionMinimum:
 		var min float64
 		for _, v := range values {

--- a/internal/curves/curve_test.go
+++ b/internal/curves/curve_test.go
@@ -205,6 +205,65 @@ func TestFunctionCurveAverage(t *testing.T) {
 	assert.Equal(t, 127, result)
 }
 
+func TestFunctionCurveDelta (t *testing.T) {
+	// GIVEN
+	temp1 := 20000.0
+	temp2 := 40000.0
+
+	s1 := MockSensor{
+		ID:        "ambient_sensor",
+		Name:      "sensor_ambient",
+		MovingAvg: temp1,
+	}
+	sensors.SensorMap[s1.GetId()] = &s1
+
+	s2 := MockSensor{
+		ID:        "water_sensor",
+		Name:      "sensor_water",
+		MovingAvg: temp2,
+	}
+	sensors.SensorMap[s2.GetId()] = &s2
+
+	curve1 :=  createLinearCurveConfig(
+		"case_fan_front",
+		s1.GetId(),
+		18,
+		60,
+	)
+	c1, err := NewSpeedCurve(curve1)
+	SpeedCurveMap[c1.GetId()] = c1
+
+	curve2 := createLinearCurveConfig(
+		"case_fan_back",
+		s2.GetId(),
+		18,
+		60,
+	)
+	c2, err := NewSpeedCurve(curve2)
+	SpeedCurveMap[c2.GetId()] = c2
+
+	function := configuration.FunctionDelta
+	functionCurveConfig := createFunctionCurveConfig(
+		"delta_function_curve",
+		function,
+		[]string{
+			curve1.ID,
+			curve2.ID,
+		},
+	)
+	functionCurve, err := NewSpeedCurve(functionCurveConfig)
+	SpeedCurveMap[functionCurve.GetId()] = functionCurve
+
+	// WHEN
+	result, err := functionCurve.Evaluate()
+	if err != nil {
+		assert.Fail(t, err.Error())
+	}
+
+	// THEN
+	assert.Equal(t, 121, result)
+}
+
 func TestFunctionCurveMinimum(t *testing.T) {
 	// GIVEN
 	temp1 := 40000.0

--- a/internal/curves/curve_test.go
+++ b/internal/curves/curve_test.go
@@ -166,7 +166,7 @@ func TestFunctionCurveAverage(t *testing.T) {
 	sensors.SensorMap[s2.GetId()] = &s2
 
 	curve1 := createLinearCurveConfig(
-		"case_fan_front",
+		"case_fan_front1",
 		s1.GetId(),
 		40,
 		80,
@@ -175,7 +175,7 @@ func TestFunctionCurveAverage(t *testing.T) {
 	SpeedCurveMap[c1.GetId()] = c1
 
 	curve2 := createLinearCurveConfig(
-		"case_fan_back",
+		"case_fan_back1",
 		s2.GetId(),
 		40,
 		80,
@@ -205,7 +205,7 @@ func TestFunctionCurveAverage(t *testing.T) {
 	assert.Equal(t, 127, result)
 }
 
-func TestFunctionCurveDelta (t *testing.T) {
+func TestFunctionCurveDelta(t *testing.T) {
 	// GIVEN
 	temp1 := 20000.0
 	temp2 := 40000.0
@@ -224,8 +224,8 @@ func TestFunctionCurveDelta (t *testing.T) {
 	}
 	sensors.SensorMap[s2.GetId()] = &s2
 
-	curve1 :=  createLinearCurveConfig(
-		"case_fan_front",
+	curve1 := createLinearCurveConfig(
+		"case_fan_front2",
 		s1.GetId(),
 		18,
 		60,
@@ -234,7 +234,7 @@ func TestFunctionCurveDelta (t *testing.T) {
 	SpeedCurveMap[c1.GetId()] = c1
 
 	curve2 := createLinearCurveConfig(
-		"case_fan_back",
+		"case_fan_back2",
 		s2.GetId(),
 		18,
 		60,
@@ -270,35 +270,40 @@ func TestFunctionCurveMinimum(t *testing.T) {
 	temp2 := 80000.0
 
 	s1 := MockSensor{
+		ID:        "s1",
 		Name:      "sensor1",
 		MovingAvg: temp1,
 	}
 	sensors.SensorMap[s1.GetId()] = &s1
 
 	s2 := MockSensor{
+		ID:        "s2",
 		Name:      "sensor2",
 		MovingAvg: temp2,
 	}
 	sensors.SensorMap[s2.GetId()] = &s2
 
 	curve1 := createLinearCurveConfig(
-		"case_fan_front",
+		"case_fan_front3",
 		s1.GetId(),
 		40,
 		80,
 	)
-	NewSpeedCurve(curve1)
+	c1, err := NewSpeedCurve(curve1)
+	SpeedCurveMap[c1.GetId()] = c1
+
 	curve2 := createLinearCurveConfig(
-		"case_fan_back",
+		"case_fan_back3",
 		s2.GetId(),
 		40,
 		80,
 	)
-	NewSpeedCurve(curve2)
+	c2, err := NewSpeedCurve(curve2)
+	SpeedCurveMap[c2.GetId()] = c2
 
 	function := configuration.FunctionMinimum
 	functionCurveConfig := createFunctionCurveConfig(
-		"max_function_curve",
+		"max_function_curve1",
 		function,
 		[]string{
 			curve1.ID,
@@ -323,35 +328,40 @@ func TestFunctionCurveMaximum(t *testing.T) {
 	temp2 := 80000.0
 
 	s1 := MockSensor{
+		ID:        "s1",
 		Name:      "sensor1",
 		MovingAvg: temp1,
 	}
 	sensors.SensorMap[s1.GetId()] = &s1
 
 	s2 := MockSensor{
+		ID:        "s1",
 		Name:      "sensor2",
 		MovingAvg: temp2,
 	}
 	sensors.SensorMap[s2.GetId()] = &s2
 
 	curve1 := createLinearCurveConfig(
-		"case_fan_front",
+		"case_fan_front4",
 		s1.GetId(),
 		40,
 		80,
 	)
-	NewSpeedCurve(curve1)
+	c1, err := NewSpeedCurve(curve1)
+	SpeedCurveMap[c1.GetId()] = c1
+
 	curve2 := createLinearCurveConfig(
-		"case_fan_back",
+		"case_fan_back4",
 		s2.GetId(),
 		40,
 		80,
 	)
-	NewSpeedCurve(curve2)
+	c2, err := NewSpeedCurve(curve2)
+	SpeedCurveMap[c2.GetId()] = c2
 
 	function := configuration.FunctionMaximum
 	functionCurveConfig := createFunctionCurveConfig(
-		"max_function_curve",
+		"max_function_curve2",
 		function,
 		[]string{
 			curve1.ID,


### PR DESCRIPTION
This change creates a curve based on the delta (difference) between the
minimum and maximum values of a collection of curves.

As an example, basing fan speed on, say, water temperature - ambient
temperature will auto adjust the fan curve throughout the day as the
room heats up and cools down, keeping noise levels consistent and
eliminating a use case for fan profiles. It might not be useful for most
users but it is a nice option to have.