### PR TITLE
internal(backend|curve): use regexp for platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ sensors:
   - id: cpu_package
     # The type of sensor configuration, one of: hwmon | file
     hwmon:
-      # The controller platform as displayed by `fan2go detect`, f.ex.:
-      # "nouveau", "coretemp" or "it8620" etc.
+      # A regex matching a controller platform displayed by `fan2go detect`, f.ex.:
+      # "coretemp", "it8620", "corsaircpro-*" etc.
       platform: coretemp
       # The index of this sensor as displayed by `fan2go detect`
       index: 1

--- a/cmd/curve.go
+++ b/cmd/curve.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 	"github.com/tomlazar/table"
+	"regexp"
 	"sort"
 	"strconv"
 )
@@ -29,7 +30,11 @@ var curveCmd = &cobra.Command{
 		for _, config := range configuration.CurrentConfig.Fans {
 			if config.HwMon != nil {
 				for _, controller := range controllers {
-					if controller.Platform == config.HwMon.Platform {
+					matched, err := regexp.MatchString("(?i)"+config.HwMon.Platform, controller.Platform)
+					if err != nil {
+						ui.Fatal("Failed to match platform regex of %s (%s) against controller platform %s", config.ID, config.HwMon.Platform, controller.Platform)
+					}
+					if matched {
 						index := config.HwMon.Index - 1
 						if len(controller.Fans) > index {
 							fan := controller.Fans[index]

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -128,7 +129,11 @@ func InitializeObjects() {
 		if config.HwMon != nil {
 			found := false
 			for _, c := range controllers {
-				if c.Platform == config.HwMon.Platform {
+				matched, err := regexp.MatchString("(?i)"+config.HwMon.Platform, c.Platform)
+				if err != nil {
+					ui.Fatal("Failed to match platform regex of %s (%s) against controller platform %s", config.ID, config.HwMon.Platform, c.Platform)
+				}
+				if matched {
 					found = true
 					config.HwMon.TempInput = c.Sensors[config.HwMon.Index-1].Input
 				}
@@ -174,7 +179,11 @@ func InitializeObjects() {
 		if config.HwMon != nil {
 			found := false
 			for _, c := range controllers {
-				if c.Platform == config.HwMon.Platform {
+				matched, err := regexp.MatchString("(?i)"+config.HwMon.Platform, c.Platform)
+				if err != nil {
+					ui.Fatal("Failed to match platform regex of %s (%s) against controller platform %s", config.ID, config.HwMon.Platform, c.Platform)
+				}
+				if matched {
 					found = true
 					index := config.HwMon.Index - 1
 					if len(c.Fans) > index {


### PR DESCRIPTION
The previous implementation required the configuration to use the exact
device name (i.e corsaircpro-hid-3-7 or amdgpu-pci-0d00) which meant if
a device booted to a different hwmon path (causing corsaircpro-hid-3-7
to be corsaircpro-hid-3-6) then it would not get picked up by fan2go.

This makes fan2go more powerful and immune to underlying changes to the
device interface that may happen when booting into a system. It also  it low key makes the README more accurate :-).