### PR TITLE
Fix "minimum" fan curve

### DIFF
--- a/internal/curves/curve.go
+++ b/internal/curves/curve.go
@@ -116,7 +116,7 @@ func (c functionSpeedCurve) Evaluate() (value int, err error) {
 		delta := dmax - dmin
 		return int(delta), nil
 	case configuration.FunctionMinimum:
-		var min float64
+		var min float64 = 255
 		for _, v := range values {
 			min = math.Min(min, float64(v))
 		}

--- a/internal/curves/curve_test.go
+++ b/internal/curves/curve_test.go
@@ -266,7 +266,7 @@ func TestFunctionCurveDelta(t *testing.T) {
 
 func TestFunctionCurveMinimum(t *testing.T) {
 	// GIVEN
-	temp1 := 40000.0
+	temp1 := 60000.0
 	temp2 := 80000.0
 
 	s1 := MockSensor{
@@ -319,7 +319,7 @@ func TestFunctionCurveMinimum(t *testing.T) {
 	}
 
 	// THEN
-	assert.Equal(t, 0, result)
+	assert.Equal(t, 127, result)
 }
 
 func TestFunctionCurveMaximum(t *testing.T) {


### PR DESCRIPTION
Hello,

first of all: Thank you very much for this program!

This PR fixes one small issue with the "minimum" fan curve.
By not setting a default value for `min`, it defaults to `0`. This causes the `math.Min` function to always return `0` and thus rendering the "minimum" curve useless.
Setting it to `255` fixes this issue.