### PR TITLE
Fix crash on invalid curve config

### DIFF
--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -56,7 +56,7 @@ func isSensorConfigInUse(config SensorConfig, curves []CurveConfig) bool {
 			// function curves cannot reference sensors
 			continue
 		}
-		if curveConfig.Linear.Sensor == config.ID {
+		if curveConfig.Linear != nil && curveConfig.Linear.Sensor == config.ID {
 			return true
 		}
 	}


### PR DESCRIPTION
If one provides an invalid curve configuration with neither `linear` nor `function` fan2go crashes with a segmentation fault.

Example config snippets (based on the example config):
```
curves:
  - id: cpu_curve
    # typo
    linearr:
      sensor: cpu_package
      steps:
        - 40: 0
        - 50: 50
        - 80: 255
```
or
```
curves:
  - id: cpu_curve
```

Crash:
``` 
INFO  Using configuration file at: /tmp/fan2go/fan2go.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x7ae3c2]
```

No clue why `TestValidateCurveSubConfigSensorIdIsMissing` doesn't catch this error.
Sorry I am not sure on how to add a test with an actual config file.