### PR TITLE
Add command-based sensor type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ run:
 	go build -o ${OUTPUT_DIR}${BINARY_NAME} main.go
 	./${OUTPUT_DIR}${BINARY_NAME}
 
+test:
+	sudo go test -v ./...
+
 clean:
 	go clean
 	rm ${OUTPUT_DIR}${BINARY_NAME}

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ The file contains a value in milli-units, like milli-degrees.
 10000
 ```
 
+```yaml
+sensors:
+  - id: cmd_fan
+    cmd:
+      exec: /usr/bin/nvidia-settings
+      args: ['-q', 'gpucoretemp', '-t']
+```
+
 ### Curves
 
 Under `curves:` you need to define a list of fan speed curves, which represent the speed of a fan based on one or more

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ sensors:
   # A user defined ID, which is used to reference
   # a sensor in a curve configuration (see below)
   - id: cpu_package
-    # The type of sensor configuration, one of: hwmon | file
+    # The type of sensor configuration, one of: hwmon | file | cmd
     hwmon:
       # A regex matching a controller platform displayed by `fan2go detect`, f.ex.:
       # "coretemp", "it8620", "corsaircpro-*" etc.
@@ -164,6 +164,7 @@ sensors:
 sensors:
   - id: file_sensor
     file:
+      # Path to the file containing sensor values
       path: /tmp/file_sensor
 ```
 
@@ -178,9 +179,14 @@ The file contains a value in milli-units, like milli-degrees.
 sensors:
   - id: cmd_fan
     cmd:
+      # Path to the executable to run to retrieve the current sensor value
       exec: /usr/bin/nvidia-settings
-      args: ['-q', 'gpucoretemp', '-t']
+      # (optional) arguments to pass to the executable
+      args: [ '-q', 'gpucoretemp', '-t' ]
 ```
+
+Please also make sure to read the section
+about [considerations for using the cmd sensor/fan](##Using external commands for sensors/fans).
 
 ### Curves
 
@@ -263,6 +269,25 @@ or to validate a specific config file:
  WARNING  Unused curve configuration: m2_first_ssd_curve
   ERROR   Validation failed: Curve m2_ssd_curve: no curve definition with id 'm2_first_ssd_curve123' found
 ```
+
+## Using external commands for sensors/fans
+
+fan2go supports using external executables for use as both sensor input, as well as fan output (and rpm input). There
+are some considerations you should take into account before using this feature though:
+
+### Security
+
+Since fan2go requires root permissions to interact with lm-sensors, executables run by fan2go are also executed as root.
+To prevent some malicious actor from taking advantage of this fan2go will only allow the execution of files that only
+allow the root user (UID 0) to modify the file.
+
+### Side effects
+
+Running external commands repeatedly through fan2go can have unintended side effects. F.ex., on a laptop using hybrid
+graphics, running `nvidia-settings` can cause the dedicated GPU to wake up, resulting in substantial increase in power
+consumption while on battery. Also, fan2go expects to be able to update sensor values with a minimal delay, so using a
+long running script or some network call with a long timeout could also cause problems. With great power comes great
+responsibility, always remember that :)
 
 ## Run
 

--- a/cmd/config/validate.go
+++ b/cmd/config/validate.go
@@ -18,7 +18,7 @@ var validateCmd = &cobra.Command{
 		ui.Info("Using configuration file at: %s", configPath)
 		configuration.LoadConfig()
 
-		if err := configuration.Validate(); err != nil {
+		if err := configuration.Validate(configPath); err != nil {
 			ui.Error("Validation failed: %v", err)
 			os.Exit(1)
 		}

--- a/cmd/curve.go
+++ b/cmd/curve.go
@@ -23,7 +23,7 @@ var curveCmd = &cobra.Command{
 		configPath := configuration.DetectConfigFile()
 		ui.Info("Using configuration file at: %s", configPath)
 		configuration.LoadConfig()
-		err := configuration.Validate()
+		err := configuration.Validate(configPath)
 		if err != nil {
 			ui.Fatal(err.Error())
 		}

--- a/cmd/fan/fan.go
+++ b/cmd/fan/fan.go
@@ -34,7 +34,7 @@ func getFan(id string) (fans.Fan, error) {
 	configPath := configuration.DetectConfigFile()
 	ui.Info("Using configuration file at: %s", configPath)
 	configuration.LoadConfig()
-	err := configuration.Validate()
+	err := configuration.Validate(configPath)
 	if err != nil {
 		ui.Fatal(err.Error())
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/markusressel/fan2go/internal"
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/ui"
+	"github.com/markusressel/fan2go/internal/util"
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
 	"os"
@@ -34,9 +35,13 @@ on your computer based on temperature sensors.`,
 		configPath := configuration.DetectConfigFile()
 		ui.Info("Using configuration file at: %s", configPath)
 		configuration.LoadConfig()
-		err := configuration.Validate()
+		err := configuration.Validate(configPath)
 		if err != nil {
 			ui.Fatal(err.Error())
+		}
+
+		if _, err := util.CheckFilePermissionsForExecution(configPath); err != nil {
+			ui.Fatal("Config file '%s' has invalid permissions: %s", configPath, err)
 		}
 
 		internal.RunDaemon()

--- a/cmd/sensor/sensor.go
+++ b/cmd/sensor/sensor.go
@@ -54,7 +54,7 @@ func getSensor(id string) (sensors.Sensor, error) {
 	configPath := configuration.DetectConfigFile()
 	ui.Info("Using configuration file at: %s", configPath)
 	configuration.LoadConfig()
-	err := configuration.Validate()
+	err := configuration.Validate(configPath)
 	if err != nil {
 		ui.Fatal(err.Error())
 	}

--- a/internal/configuration/sensors.go
+++ b/internal/configuration/sensors.go
@@ -4,6 +4,7 @@ type SensorConfig struct {
 	ID    string             `json:"id"`
 	HwMon *HwMonSensorConfig `json:"hwMon,omitempty"`
 	File  *FileSensorConfig  `json:"file,omitempty"`
+	Cmd   *CmdSensorConfig   `json:"cmd,omitempty"`
 }
 
 type HwMonSensorConfig struct {
@@ -14,4 +15,9 @@ type HwMonSensorConfig struct {
 
 type FileSensorConfig struct {
 	Path string `json:"path"`
+}
+
+type CmdSensorConfig struct {
+	Exec string   `json:"exec"`
+	Args []string `json:"args"`
 }

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -28,12 +28,13 @@ func ValidateConfig(config *Configuration) error {
 
 func validateSensors(config *Configuration) error {
 	for _, sensorConfig := range config.Sensors {
-		if sensorConfig.HwMon != nil && sensorConfig.File != nil {
+
+		if sensorConfig.HwMon != nil && sensorConfig.File != nil && sensorConfig.Cmd != nil {
 			return errors.New(fmt.Sprintf("Sensor %s: only one sensor type can be used per sensor definition block", sensorConfig.ID))
 		}
 
-		if sensorConfig.HwMon == nil && sensorConfig.File == nil {
-			return errors.New(fmt.Sprintf("Sensor %s: sub-configuration for sensor is missing, use one of: hwmon | file", sensorConfig.ID))
+		if sensorConfig.HwMon == nil && sensorConfig.File == nil && sensorConfig.Cmd == nil {
+			return errors.New(fmt.Sprintf("Sensor %s: sub-configuration for sensor is missing, use one of: hwmon | file | cmd", sensorConfig.ID))
 		}
 
 		if !isSensorConfigInUse(sensorConfig, config.Curves) {
@@ -158,7 +159,7 @@ func validateFans(config *Configuration) error {
 		}
 
 		if fanConfig.HwMon == nil && fanConfig.File == nil {
-			return errors.New(fmt.Sprintf("Fans %s: sub-configuration for fan is missing, use one of: hwmon | file", fanConfig.ID))
+			return errors.New(fmt.Sprintf("Fans %s: sub-configuration for fan is missing, use one of: hwmon | file | cmd", fanConfig.ID))
 		}
 
 		if len(fanConfig.Curve) <= 0 {

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -8,7 +8,11 @@ import (
 	"github.com/markusressel/fan2go/internal/util"
 )
 
-func Validate() error {
+func Validate(configPath string) error {
+	if _, err := util.CheckFilePermissionsForExecution(configPath); err != nil {
+		return errors.New(fmt.Sprintf("Config file '%s' has invalid permissions: %s", configPath, err))
+	}
+
 	return ValidateConfig(&CurrentConfig)
 }
 

--- a/internal/configuration/validation_test.go
+++ b/internal/configuration/validation_test.go
@@ -22,7 +22,7 @@ func TestValidateFanSubConfigIsMissing(t *testing.T) {
 	err := ValidateConfig(&config)
 
 	// THEN
-	assert.EqualError(t, err, "Fans fan: sub-configuration for fan is missing, use one of: hwmon | file")
+	assert.EqualError(t, err, "Fans fan: sub-configuration for fan is missing, use one of: hwmon | file | cmd")
 }
 
 func TestValidateFanCurveWithIdIsNotDefined(t *testing.T) {
@@ -254,7 +254,7 @@ func TestValidateSensorSubConfigSensorIdIsMissing(t *testing.T) {
 	err := ValidateConfig(&config)
 
 	// THEN
-	assert.EqualError(t, err, "Sensor sensor: sub-configuration for sensor is missing, use one of: hwmon | file")
+	assert.EqualError(t, err, "Sensor sensor: sub-configuration for sensor is missing, use one of: hwmon | file | cmd")
 }
 
 func TestValidateSensor(t *testing.T) {

--- a/internal/sensors/cmd.go
+++ b/internal/sensors/cmd.go
@@ -1,0 +1,54 @@
+package sensors
+
+import (
+	"github.com/markusressel/fan2go/internal/configuration"
+	"github.com/markusressel/fan2go/internal/ui"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type CmdSensor struct {
+	Name      string                     `json:"name"`
+	Exec      string                     `json:"exec"`
+	Args      []string                   `json:"args"`
+	Config    configuration.SensorConfig `json:"configuration"`
+	MovingAvg float64                    `json:"moving_avg"`
+}
+
+func (sensor CmdSensor) GetId() string {
+	return sensor.Config.ID
+}
+
+func (sensor CmdSensor) GetConfig() configuration.SensorConfig {
+	return sensor.Config
+}
+
+func (sensor CmdSensor) GetValue() (float64, error) {
+	cmd := exec.Command(sensor.Exec, sensor.Args...)
+
+	out, err := cmd.Output()
+	if err != nil {
+		ui.Warning("Command failed to execute: %s", sensor.Exec)
+		return 0, err
+	}
+
+	strout := string(out)
+	strout = strings.Trim(strout, "\n")
+
+	temp, err := strconv.ParseFloat(strout, 64)
+	if err != nil {
+		ui.Warning("Unable to read int from command output: %s", sensor.Exec)
+		return 0, err
+	}
+
+	return temp, nil
+}
+
+func (sensor CmdSensor) GetMovingAvg() (avg float64) {
+	return sensor.MovingAvg
+}
+
+func (sensor *CmdSensor) SetMovingAvg(avg float64) {
+	sensor.MovingAvg = avg
+}

--- a/internal/sensors/cmd.go
+++ b/internal/sensors/cmd.go
@@ -1,8 +1,11 @@
 package sensors
 
 import (
+	"errors"
+	"fmt"
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/ui"
+	"github.com/markusressel/fan2go/internal/util"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -25,6 +28,10 @@ func (sensor CmdSensor) GetConfig() configuration.SensorConfig {
 }
 
 func (sensor CmdSensor) GetValue() (float64, error) {
+	if _, err := util.CheckFilePermissionsForExecution(sensor.Exec); err != nil {
+		return 0, errors.New(fmt.Sprintf("Cannot execute %s: %s", sensor.Exec, err))
+	}
+
 	cmd := exec.Command(sensor.Exec, sensor.Args...)
 
 	out, err := cmd.Output()

--- a/internal/sensors/common.go
+++ b/internal/sensors/common.go
@@ -39,5 +39,14 @@ func NewSensor(config configuration.SensorConfig) (Sensor, error) {
 		}, nil
 	}
 
+	if config.Cmd != nil {
+		return &CmdSensor{
+			Name:   config.ID,
+			Exec:   config.Cmd.Exec,
+			Args:   config.Cmd.Args,
+			Config: config,
+		}, nil
+	}
+
 	return nil, fmt.Errorf("no matching sensor type for sensor: %s", config.ID)
 }

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -1,0 +1,101 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+// TODO: these tests need to run as root
+
+func TestFileHasPermissionsUserIsRoot(t *testing.T) {
+	// GIVEN
+	filePath := "./testfile"
+
+	filePerm := os.FileMode(0o700)
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePerm)
+	assert.NoError(t, err)
+	err = os.Chown(filePath, 0, 1000)
+	assert.NoError(t, err)
+	err = os.Chmod(filePath, filePerm)
+	assert.NoError(t, err)
+
+	defer file.Close()
+	defer os.Remove(filePath)
+
+	// WHEN
+	result, err := CheckFilePermissionsForExecution(filePath)
+
+	// THEN
+	assert.Equal(t, true, result)
+	assert.NoError(t, err)
+}
+
+func TestFileHasPermissionsGroupIsRootAndHasWrite(t *testing.T) {
+	// GIVEN
+	filePath := "./testfile"
+
+	filePerm := os.FileMode(0o770)
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePerm)
+	assert.NoError(t, err)
+	err = os.Chown(filePath, 0, 0)
+	assert.NoError(t, err)
+	err = os.Chmod(filePath, filePerm)
+	assert.NoError(t, err)
+
+	defer file.Close()
+	defer os.Remove(filePath)
+
+	// WHEN
+	result, err := CheckFilePermissionsForExecution(filePath)
+
+	// THEN
+	assert.Equal(t, true, result)
+	assert.NoError(t, err)
+}
+
+func TestFileHasPermissionsGroupOtherThanRootHasWritePermission(t *testing.T) {
+	// GIVEN
+	filePath := "./testfile"
+
+	filePerm := os.FileMode(0o720)
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePerm)
+	assert.NoError(t, err)
+	err = os.Chown(filePath, 0, 1000)
+	assert.NoError(t, err)
+	err = os.Chmod(filePath, filePerm)
+	assert.NoError(t, err)
+
+	defer file.Close()
+	defer os.Remove(filePath)
+
+	// WHEN
+	result, err := CheckFilePermissionsForExecution(filePath)
+
+	// THEN
+	assert.Equal(t, false, result)
+	assert.Error(t, err)
+}
+
+func TestFileHasPermissionsOtherHasWritePermission(t *testing.T) {
+	// GIVEN
+	filePath := "./testfile"
+
+	filePerm := os.FileMode(0o702)
+	file, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, filePerm)
+	assert.NoError(t, err)
+	err = os.Chown(filePath, 0, 1000)
+	assert.NoError(t, err)
+	err = os.Chmod(filePath, filePerm)
+	assert.NoError(t, err)
+
+	defer file.Close()
+	defer os.Remove(filePath)
+
+	// WHEN
+	result, err := CheckFilePermissionsForExecution(filePath)
+
+	// THEN
+	assert.Equal(t, false, result)
+	assert.Error(t, err)
+}

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 )
 
-// TODO: these tests need to run as root
-
 func TestFileHasPermissionsUserIsRoot(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping tests which require root")
+	}
+
 	// GIVEN
 	filePath := "./testfile"
 
@@ -32,6 +34,10 @@ func TestFileHasPermissionsUserIsRoot(t *testing.T) {
 }
 
 func TestFileHasPermissionsGroupIsRootAndHasWrite(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping tests which require root")
+	}
+
 	// GIVEN
 	filePath := "./testfile"
 
@@ -55,6 +61,10 @@ func TestFileHasPermissionsGroupIsRootAndHasWrite(t *testing.T) {
 }
 
 func TestFileHasPermissionsGroupOtherThanRootHasWritePermission(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping tests which require root")
+	}
+
 	// GIVEN
 	filePath := "./testfile"
 
@@ -78,6 +88,10 @@ func TestFileHasPermissionsGroupOtherThanRootHasWritePermission(t *testing.T) {
 }
 
 func TestFileHasPermissionsOtherHasWritePermission(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Skipping tests which require root")
+	}
+
 	// GIVEN
 	filePath := "./testfile"
 


### PR DESCRIPTION
I was playing around with the program and thought I would contribute this back.

For some reason `sensors-detect` doesn't spit out my GPU temperature sensor, so I decided to first try and get it from a file that's constantly being updated - this turned out to be a pain.

I then decided to modify it by adding a new command-based sensor type. It could also conceivably be used to get temperatures from anywhere - something like the temperature of the room could be interesting.