### PR TITLE
fix pwm config overrides not beeing applied correctly

### DIFF
--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -5,7 +5,7 @@ type FanConfig struct {
 	NeverStop bool   `json:"neverStop"`
 	// MinPwm defines the lowest PWM value where the fans are still spinning, when spinning previously
 	MinPwm *int `json:"minPwm,omitempty"`
-	// MinPwm defines the lowest PWM value where the fans are able to start spinning from a standstill
+	// StartPwm defines the lowest PWM value where the fans are able to start spinning from a standstill
 	StartPwm *int `json:"startPwm,omitempty"`
 	// MaxPwm defines the highest PWM value that yields an RPM increase
 	MaxPwm      *int               `json:"maxPwm,omitempty"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -136,6 +136,10 @@ func (f *fanController) Run(ctx context.Context) error {
 	ui.Info("PWM settings of fan '%s': Min %d, Start %d, Max %d", fan.GetId(), fan.GetMinPwm(), fan.GetStartPwm(), fan.GetMaxPwm())
 	ui.Info("Starting controller loop for fan '%s'", fan.GetId())
 
+	if fan.GetMinPwm() > fan.GetStartPwm() {
+		ui.Warning("Suspicious pwm config of fan '%s': MinPwm (%d) > StartPwm (%d)", fan.GetId(), fan.GetMinPwm(), fan.GetStartPwm())
+	}
+
 	var g run.Group
 
 	if fan.Supports(fans.FeatureRpmSensor) {
@@ -413,7 +417,7 @@ func (f *fanController) calculateTargetPwm() int {
 				}
 				ui.Warning("WARNING: Increasing minPWM of %s from %d to %d, which is supposed to never stop, but RPM is %d",
 					fan.GetId(), fan.GetMinPwm(), fan.GetMinPwm()+1, int(avgRpm))
-				fan.SetMinPwm(fan.GetMinPwm() + 1)
+				fan.SetMinPwm(fan.GetMinPwm()+1, true)
 				target++
 
 				// set the moving avg to a value > 0 to prevent

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -69,7 +69,7 @@ func (fan MockFan) GetStartPwm() int {
 	return 0
 }
 
-func (fan *MockFan) SetStartPwm(pwm int) {
+func (fan *MockFan) SetStartPwm(pwm int, force bool) {
 	panic("not supported")
 }
 
@@ -77,7 +77,7 @@ func (fan MockFan) GetMinPwm() int {
 	return fan.MinPWM
 }
 
-func (fan *MockFan) SetMinPwm(pwm int) {
+func (fan *MockFan) SetMinPwm(pwm int, force bool) {
 	fan.MinPWM = pwm
 }
 
@@ -85,7 +85,7 @@ func (fan MockFan) GetMaxPwm() int {
 	return fans.MaxPwmValue
 }
 
-func (fan *MockFan) SetMaxPwm(pwm int) {
+func (fan *MockFan) SetMaxPwm(pwm int, force bool) {
 	panic("not supported")
 }
 

--- a/internal/fans/cmd.go
+++ b/internal/fans/cmd.go
@@ -27,7 +27,7 @@ func (fan CmdFan) GetStartPwm() int {
 	return 1
 }
 
-func (fan *CmdFan) SetStartPwm(pwm int) {
+func (fan *CmdFan) SetStartPwm(pwm int, force bool) {
 	return
 }
 
@@ -35,7 +35,7 @@ func (fan CmdFan) GetMinPwm() int {
 	return MinPwmValue
 }
 
-func (fan *CmdFan) SetMinPwm(pwm int) {
+func (fan *CmdFan) SetMinPwm(pwm int, force bool) {
 	// not supported
 	return
 }
@@ -44,7 +44,7 @@ func (fan CmdFan) GetMaxPwm() int {
 	return MaxPwmValue
 }
 
-func (fan *CmdFan) SetMaxPwm(pwm int) {
+func (fan *CmdFan) SetMaxPwm(pwm int, force bool) {
 	// not supported
 	return
 }

--- a/internal/fans/common.go
+++ b/internal/fans/common.go
@@ -36,17 +36,17 @@ var (
 type Fan interface {
 	GetId() string
 
-	// GetStartPwm returns the min PWM at which the fan starts to rotate from a stand still
-	GetStartPwm() int
-	SetStartPwm(pwm int)
-
 	// GetMinPwm returns the lowest PWM value where the fans are still spinning, when spinning previously
 	GetMinPwm() int
-	SetMinPwm(pwm int)
+	SetMinPwm(pwm int, force bool)
+
+	// GetStartPwm returns the min PWM at which the fan starts to rotate from a stand still
+	GetStartPwm() int
+	SetStartPwm(pwm int, force bool)
 
 	// GetMaxPwm returns the highest PWM value that yields an RPM increase
 	GetMaxPwm() int
-	SetMaxPwm(pwm int)
+	SetMaxPwm(pwm int, force bool)
 
 	// GetRpm returns the current RPM value of this fan
 	GetRpm() (int, error)
@@ -81,7 +81,9 @@ func NewFan(config configuration.FanConfig) (Fan, error) {
 		return &HwMonFan{
 			Label:    config.ID,
 			Index:    config.HwMon.Index,
+			MinPwm:   config.MinPwm,
 			StartPwm: config.StartPwm,
+			MaxPwm:   config.MaxPwm,
 			Config:   config,
 		}, nil
 	}

--- a/internal/fans/file.go
+++ b/internal/fans/file.go
@@ -24,7 +24,7 @@ func (fan FileFan) GetStartPwm() int {
 	return 1
 }
 
-func (fan *FileFan) SetStartPwm(pwm int) {
+func (fan *FileFan) SetStartPwm(pwm int, force bool) {
 	return
 }
 
@@ -32,7 +32,7 @@ func (fan FileFan) GetMinPwm() int {
 	return MinPwmValue
 }
 
-func (fan *FileFan) SetMinPwm(pwm int) {
+func (fan *FileFan) SetMinPwm(pwm int, force bool) {
 	// not supported
 	return
 }
@@ -41,7 +41,7 @@ func (fan FileFan) GetMaxPwm() int {
 	return MaxPwmValue
 }
 
-func (fan *FileFan) SetMaxPwm(pwm int) {
+func (fan *FileFan) SetMaxPwm(pwm int, force bool) {
 	// not supported
 	return
 }

--- a/internal/fans/hwmon_test.go
+++ b/internal/fans/hwmon_test.go
@@ -37,6 +37,7 @@ func TestHwMonFan_ShouldNeverStop_GetMinPwm(t *testing.T) {
 	// GIVEN
 	expected := 30
 	fan := HwMonFan{
+		MinPwm: &expected,
 		Config: configuration.FanConfig{
 			NeverStop: true,
 			MinPwm:    &expected,
@@ -73,6 +74,7 @@ func TestHwMonFan_GetMaxPwm(t *testing.T) {
 	// GIVEN
 	expected := 240
 	fan := HwMonFan{
+		MaxPwm: &expected,
 		Config: configuration.FanConfig{
 			MaxPwm: &expected,
 		},

--- a/internal/fans/hwmon_test.go
+++ b/internal/fans/hwmon_test.go
@@ -26,7 +26,7 @@ func TestHwMonFan_SetStartPwm(t *testing.T) {
 	fan := HwMonFan{}
 
 	// WHEN
-	fan.SetStartPwm(expected)
+	fan.SetStartPwm(expected, false)
 	startPwm := fan.GetStartPwm()
 
 	// THEN
@@ -91,7 +91,7 @@ func TestHwMonFan_SetMaxPwm(t *testing.T) {
 	fan := HwMonFan{}
 
 	// WHEN
-	fan.SetMaxPwm(expected)
+	fan.SetMaxPwm(expected, false)
 	maxPwm := fan.GetMaxPwm()
 
 	// THEN


### PR DESCRIPTION
rework how min/start/max pwm values are set on HwMon fans to fix issue with applying config overrides

contributes to #161 