### PR TITLE
Feature/#161 override pwm map from config

### DIFF
--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -52,6 +52,15 @@ fans:
     # an increased rotational speed compared to lower values.
     # Note: you can also use this to limit the max speed of a fan.
     maxPwm: 255
+    # (Optional) Override for the PWM map used internally by fan2go for
+    # mapping the "normal" 0-255 value range to values supported by this fan.
+    # This can be used to compensate for a very limited set of supported values
+    # (f.ex. off, low, high). If not set manually, the map will be computed
+    # automatically by fan2go during fan initialization.
+    pwmMap:
+      0: 0
+      64: 128
+      192: 255
 
   - id: in_front
     hwmon:

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -8,6 +8,7 @@ type FanConfig struct {
 	// StartPwm defines the lowest PWM value where the fans are able to start spinning from a standstill
 	StartPwm *int `json:"startPwm,omitempty"`
 	// MaxPwm defines the highest PWM value that yields an RPM increase
+	PwmMap      *map[int]int       `json:"pwmMap,omitempty"`
 	MaxPwm      *int               `json:"maxPwm,omitempty"`
 	Curve       string             `json:"curve"`
 	HwMon       *HwMonFanConfig    `json:"hwMon,omitempty"`

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -420,7 +420,7 @@ func TestFanController_UpdateFanSpeed_FanCurveGaps(t *testing.T) {
 	}
 	sensors.SensorMap[s.GetId()] = &s
 
-	curveValue := 10
+	curveValue := 5
 	curve := &MockCurve{
 		ID:    "curve",
 		Value: curveValue,
@@ -444,19 +444,21 @@ func TestFanController_UpdateFanSpeed_FanCurveGaps(t *testing.T) {
 	}
 	sort.Ints(keys)
 
+	pwmMap := map[int]int{
+		0:   0,
+		1:   1,
+		40:  40,
+		58:  50,
+		100: 120,
+		222: 200,
+		255: 255,
+	}
+
 	controller := fanController{
 		persistence: mockPersistence{}, fan: fan,
 		curve:      curve,
 		updateRate: time.Duration(100),
-		pwmMap: map[int]int{
-			0:   0,
-			1:   1,
-			40:  40,
-			58:  50,
-			100: 120,
-			222: 200,
-			255: 255,
-		},
+		pwmMap:     pwmMap,
 	}
 	controller.updateDistinctPwmValues()
 
@@ -464,6 +466,9 @@ func TestFanController_UpdateFanSpeed_FanCurveGaps(t *testing.T) {
 	targetPwm := controller.calculateTargetPwm()
 
 	// THEN
-	assert.Contains(t, keys, targetPwm)
-	assert.Equal(t, 50, targetPwm)
+	assert.Contains(t, pwmMap, targetPwm)
+	assert.Equal(t, 54, targetPwm)
+
+	closestTarget := controller.mapToClosestDistinct(targetPwm)
+	assert.Equal(t, 50, closestTarget)
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -466,7 +466,6 @@ func TestFanController_UpdateFanSpeed_FanCurveGaps(t *testing.T) {
 	targetPwm := controller.calculateTargetPwm()
 
 	// THEN
-	assert.Contains(t, pwmMap, targetPwm)
 	assert.Equal(t, 54, targetPwm)
 
 	closestTarget := controller.mapToClosestDistinct(targetPwm)


### PR DESCRIPTION
Adds the ability to override the (normally) automatically computed `pwmMap` used internally in fan2go to map the 0-255 range to supported values by each fan.

contributes to #161