### PR TITLE
Do not hard-fail on process owner check

### DIFF
--- a/internal/backend.go
+++ b/internal/backend.go
@@ -29,8 +29,7 @@ func RunDaemon() {
 	owner, err := getProcessOwner()
 	if err != nil {
 		ui.Warning("Unable to verify process owner: %v", err)
-	}
-	if owner != "root" {
+	} else if owner != "root" {
 		ui.Info("fan2go is running as a non-root user '%s'. If you encounter errors, make sure to give this user the required permissions.", owner)
 	}
 

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -28,7 +28,7 @@ import (
 )
 
 func RunDaemon() {
-	if getProcessOwner() != "root" {
+	if owner, err := getProcessOwner(); err != nil && owner != "root" {
 		ui.Fatal("Fan control requires root permissions to be able to modify fan speeds, please run fan2go as root")
 	}
 
@@ -322,11 +322,10 @@ func initializeFans(controllers []*hwmon.HwMonController) map[configuration.FanC
 	return result
 }
 
-func getProcessOwner() string {
+func getProcessOwner() (string, error) {
 	stdout, err := exec.Command("ps", "-o", "user=", "-p", strconv.Itoa(os.Getpid())).Output()
 	if err != nil {
-		ui.Fatal("Error checking process owner: %v", err)
-		os.Exit(1)
+		return "", err
 	}
-	return strings.TrimSpace(string(stdout))
+	return strings.TrimSpace(string(stdout)), nil
 }


### PR DESCRIPTION

`ps` might be missing in $PATH, or fan2go might be running as a non-root user with write access to the subsystem. I don't think it's reasonable to crash the program for a simple uid check that might actually be wrong. This will eventually crash later when trying to modify paths as non-root anyway.