### PR TITLE
append chip address to isa devices (just like pci devices)

### DIFF
--- a/internal/hwmon/hwmon.go
+++ b/internal/hwmon/hwmon.go
@@ -272,17 +272,17 @@ func computeIdentifier(chip gosensors.Chip) (name string) {
 	identifier := name
 	switch chip.Bus.Type {
 	case BusTypeIsa:
-		identifier = fmt.Sprintf("%s-isa-%d%x", identifier, chip.Bus.Nr, chip.Addr)
+		identifier = fmt.Sprintf("%s-isa-%d%03x", name, chip.Bus.Nr, chip.Addr)
 	case BusTypePci:
-		identifier = fmt.Sprintf("%s-pci-%d%x", identifier, chip.Bus.Nr, chip.Addr)
+		identifier = fmt.Sprintf("%s-pci-%d%03x", name, chip.Bus.Nr, chip.Addr)
 	case BusTypeVirtual:
-		identifier = fmt.Sprintf("%s-virtual-%d", identifier, chip.Bus.Nr)
+		identifier = fmt.Sprintf("%s-virtual-%d", name, chip.Bus.Nr)
 	case BusTypeAcpi:
-		identifier = fmt.Sprintf("%s-acpi-%d", identifier, chip.Bus.Nr)
+		identifier = fmt.Sprintf("%s-acpi-%d", name, chip.Bus.Nr)
 	case BusTypeHid:
-		identifier = fmt.Sprintf("%s-hid-%d-%d", identifier, chip.Bus.Nr, chip.Addr)
+		identifier = fmt.Sprintf("%s-hid-%d-%d", name, chip.Bus.Nr, chip.Addr)
 	case BusTypeScsi:
-		identifier = fmt.Sprintf("%s-scsi-%d-%d", identifier, chip.Bus.Nr, chip.Addr)
+		identifier = fmt.Sprintf("%s-scsi-%d-%d", name, chip.Bus.Nr, chip.Addr)
 	}
 
 	return identifier

--- a/internal/hwmon/hwmon.go
+++ b/internal/hwmon/hwmon.go
@@ -272,7 +272,7 @@ func computeIdentifier(chip gosensors.Chip) (name string) {
 	identifier := name
 	switch chip.Bus.Type {
 	case BusTypeIsa:
-		identifier = fmt.Sprintf("%s-isa-%d", identifier, chip.Bus.Nr)
+		identifier = fmt.Sprintf("%s-isa-%d%x", identifier, chip.Bus.Nr, chip.Addr)
 	case BusTypePci:
 		identifier = fmt.Sprintf("%s-pci-%d%x", identifier, chip.Bus.Nr, chip.Addr)
 	case BusTypeVirtual:

--- a/internal/hwmon/hwmon_test.go
+++ b/internal/hwmon/hwmon_test.go
@@ -11,13 +11,14 @@ func TestComputeIdentifierIsa(t *testing.T) {
 	// GIVEN
 	c := gosensors.Chip{
 		Prefix: "ucsi_source_psy_USBC000:002",
+		Addr:   0x0f1,
 		Bus: gosensors.Bus{
 			Type: BusTypeIsa,
 			Nr:   1,
 		},
 		Path: "/sys/class/hwmon/hwmon7",
 	}
-	expected := fmt.Sprintf("%s-isa-%d", c.Prefix, c.Bus.Nr)
+	expected := "ucsi_source_psy_USBC000:002-isa-10f1"
 
 	// WHEN
 	result := computeIdentifier(c)
@@ -30,14 +31,14 @@ func TestComputeIdentifierPci(t *testing.T) {
 	// GIVEN
 	c := gosensors.Chip{
 		Prefix: "nvme",
-		Addr:   5,
+		Addr:   0x5,
 		Bus: gosensors.Bus{
 			Type: BusTypePci,
 			Nr:   1,
 		},
 		Path: "/sys/class/hwmon/hwmon4",
 	}
-	expected := fmt.Sprintf("%s-pci-%d%x", c.Prefix, c.Bus.Nr, c.Addr)
+	expected := "nvme-pci-1005"
 
 	// WHEN
 	result := computeIdentifier(c)


### PR DESCRIPTION
fixes #188

Uses a 3 digit padded hex value for `pci` and `isa` devices.

`asusec-isa-0` -> `asusec-isa-0000`
`nct6798-isa-0290` -> `nct6798-isa-0290`

`amdgpu-pci-0f00` -> `amdgpu-pci-0f00`
`amdgpu-pci-01` -> `amdgpu-pci-0001`
