### PR TITLE
Support disjoint fan and pwm configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,22 +115,30 @@ system run `fan2go detect`, which will print a list of devices exposed by the hw
 ```shell
 > fan2go detect
 nct6798
- Fans      Index   Label    RPM    PWM   Auto
-           1       hwmon4   0      153   false
-           2       hwmon4   1223   104   false
-           3       hwmon4   677    107   false
+ Fans     Index  Channel  Label        RPM   PWM  Auto
+          1      1        hwmon4/fan1  0     153  false
+          2      2        hwmon4/fan2  1223  104  false
+          3      3        hwmon4/fan3  677   107  false
  Sensors   Index   Label    Value
            1       SYSTIN   41000
            2       CPUTIN   64000
 
 amdgpu-pci-0031
- Fans      Index   Label    RPM   PWM   Auto
-           1       hwmon8   561   43    false
+ Fans     Index  Channel  Label        RPM   PWM  Auto
+          1      1        hwmon8/fan1  561   43   false
  Sensors   Index   Label      Value
            1       edge       58000
            2       junction   61000
            3       mem        56000
 ```
+
+The fan index is based on device enumeration and is not stable for a given fan if hardware configuration changes.
+The Linux kernel hwmon channel is a better identifier for configuration as it is largely based on the fan headers
+in use.
+
+Fan RPM, PWM, and temperature sensors are independent and Linux does not associate them automatically. A given PWM
+may control more than one fan, and a fan may not be under the control of a PWM. By default, fan2go guesses and sets
+the pwm channel number for a given fan to the fan's RPM sensor channel. You can override this in the config.
 
 #### HwMon
 
@@ -147,8 +155,10 @@ fans:
       # The platform of the controller which is
       # connected to this fan (see sensor.platform below)
       platform: nct6798
-      # The index of this fan as displayed by `fan2go detect`
-      index: 1
+      # The channel of this fan's RPM sensor as displayed by `fan2go detect`
+      channel: 1
+      # The pwm channel that controls this fan; fan2go defaults to same channel number as fan RPM
+      pwmChannel: 1
     # Indicates whether this fan should never stop rotating, regardless of
     # how low the curve value is
     neverStop: true

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ fans:
       # connected to this fan (see sensor.platform below)
       platform: nct6798
       # The channel of this fan's RPM sensor as displayed by `fan2go detect`
-      channel: 1
+      rpmChannel: 1
       # The pwm channel that controls this fan; fan2go defaults to same channel number as fan RPM
       pwmChannel: 1
     # Indicates whether this fan should never stop rotating, regardless of

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
+	"sort"
+	"strconv"
+
 	"github.com/markusressel/fan2go/cmd/global"
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/fans"
@@ -11,9 +15,6 @@ import (
 	"github.com/mgutz/ansi"
 	"github.com/spf13/cobra"
 	"github.com/tomlazar/table"
-	"path/filepath"
-	"sort"
-	"strconv"
 )
 
 var detectCmd = &cobra.Command{
@@ -42,25 +43,17 @@ var detectCmd = &cobra.Command{
 				continue
 			}
 
-			fanMap := controller.Fans
+			fanSlice := controller.Fans
 			sensorMap := controller.Sensors
 
-			if len(fanMap) <= 0 && len(sensorMap) <= 0 {
+			if len(fanSlice) <= 0 && len(sensorMap) <= 0 {
 				continue
 			}
 
 			ui.Printfln("> %s", controller.Name)
 
-			fanMapKeys := make([]int, 0, len(fanMap))
-			for k := range fanMap {
-				fanMapKeys = append(fanMapKeys, k)
-			}
-			sort.Ints(fanMapKeys)
-
 			var fanRows [][]string
-			for _, index := range fanMapKeys {
-				fan := fanMap[index]
-
+			for _, fan := range fanSlice {
 				pwmText := "N/A"
 				pwm, err := fan.GetPwm()
 				if err == nil {
@@ -77,10 +70,10 @@ var detectCmd = &cobra.Command{
 
 				isAuto, _ := fan.IsPwmAuto()
 				fanRows = append(fanRows, []string{
-					"", strconv.Itoa(fan.Index), fan.Label, rpmText, pwmText, fmt.Sprintf("%v", isAuto),
+					"", strconv.Itoa(fan.Index), strconv.Itoa(fan.Config.HwMon.Channel), fan.Label, rpmText, pwmText, fmt.Sprintf("%v", isAuto),
 				})
 			}
-			var fanHeaders = []string{"Fans   ", "Index", "Label", "RPM", "PWM", "Auto"}
+			var fanHeaders = []string{"Fans   ", "Index", "Channel", "Label", "RPM", "PWM", "Auto"}
 
 			fanTable := table.Table{
 				Headers: fanHeaders,

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -70,7 +70,7 @@ var detectCmd = &cobra.Command{
 
 				isAuto, _ := fan.IsPwmAuto()
 				fanRows = append(fanRows, []string{
-					"", strconv.Itoa(fan.Index), strconv.Itoa(fan.Config.HwMon.Channel), fan.Label, rpmText, pwmText, fmt.Sprintf("%v", isAuto),
+					"", strconv.Itoa(fan.Index), strconv.Itoa(fan.Config.HwMon.RpmChannel), fan.Label, rpmText, pwmText, fmt.Sprintf("%v", isAuto),
 				})
 			}
 			var fanHeaders = []string{"Fans   ", "Index", "Channel", "Label", "RPM", "PWM", "Auto"}

--- a/cmd/fan/fan.go
+++ b/cmd/fan/fan.go
@@ -3,12 +3,12 @@ package fan
 import (
 	"errors"
 	"fmt"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/fans"
 	"github.com/markusressel/fan2go/internal/hwmon"
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/spf13/cobra"
-	"regexp"
 )
 
 var fanId string
@@ -46,19 +46,7 @@ func getFan(id string) (fans.Fan, error) {
 		availableFanIds = append(availableFanIds, config.ID)
 		if config.ID == id {
 			if config.HwMon != nil {
-				for _, controller := range controllers {
-					matched, err := regexp.MatchString("(?i)"+config.HwMon.Platform, controller.Platform)
-					if err != nil {
-						return nil, errors.New(fmt.Sprintf("Failed to match platform regex of %s (%s) against controller platform %s", config.ID, config.HwMon.Platform, controller.Platform))
-					}
-
-					if matched {
-						fan := controller.Fans[config.HwMon.Index]
-						config.HwMon.PwmOutput = fan.Config.HwMon.PwmOutput
-						config.HwMon.RpmInput = fan.Config.HwMon.RpmInput
-						break
-					}
-				}
+				_ = hwmon.UpdateFanConfigFromHwMonControllers(controllers, &config)
 			}
 
 			fan, err := fans.NewFan(config)

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -32,8 +32,10 @@ fans:
       # The platform of the controller which is
       # connected to this fan (see sensor.platform below)
       platform: nct6798-isa-0
-      # The index of this fan as displayed by `fan2go detect`
-      index: 1
+      # The channel of this fan's RPM sensor as displayed by `fan2go detect`
+      channel: 1
+      # The pwm channel that controls this fan; fan2go defaults to same channel number as fan RPM
+      pwmChannel: 1
     # Indicates whether this fan should never stop rotating, regardless of
     # how low the curve value is
     neverStop: true
@@ -65,14 +67,14 @@ fans:
   - id: in_front
     hwmon:
       platform: it8620
-      index: 4
+      channel: 4
     neverStop: true
     curve: case_avg_curve
 
   - id: out_back
     hwmon:
       platform: it8620
-      index: 5
+      channel: 5
     neverStop: true
     curve: case_avg_curve
 

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -33,7 +33,7 @@ fans:
       # connected to this fan (see sensor.platform below)
       platform: nct6798-isa-0
       # The channel of this fan's RPM sensor as displayed by `fan2go detect`
-      channel: 1
+      rpmChannel: 1
       # The pwm channel that controls this fan; fan2go defaults to same channel number as fan RPM
       pwmChannel: 1
     # Indicates whether this fan should never stop rotating, regardless of
@@ -67,14 +67,14 @@ fans:
   - id: in_front
     hwmon:
       platform: it8620
-      channel: 4
+      rpmChannel: 4
     neverStop: true
     curve: case_avg_curve
 
   - id: out_back
     hwmon:
       platform: it8620
-      channel: 5
+      rpmChannel: 5
     neverStop: true
     curve: case_avg_curve
 

--- a/internal/backend.go
+++ b/internal/backend.go
@@ -3,6 +3,15 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"os/signal"
+	"os/user"
+	"regexp"
+	"syscall"
+	"time"
+
 	"github.com/labstack/echo/v4"
 	"github.com/markusressel/fan2go/internal/api"
 	"github.com/markusressel/fan2go/internal/configuration"
@@ -16,14 +25,6 @@ import (
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/oklog/run"
-	"net/http"
-	"net/http/pprof"
-	"os"
-	"os/signal"
-	"os/user"
-	"regexp"
-	"syscall"
-	"time"
 )
 
 func RunDaemon() {
@@ -320,22 +321,9 @@ func initializeFans(controllers []*hwmon.HwMonController) map[configuration.FanC
 
 	for _, config := range configuration.CurrentConfig.Fans {
 		if config.HwMon != nil {
-			found := false
-			for _, c := range controllers {
-				matched, err := regexp.MatchString("(?i)"+config.HwMon.Platform, c.Platform)
-				if err != nil {
-					ui.Fatal("Failed to match platform regex of %s (%s) against controller platform %s", config.ID, config.HwMon.Platform, c.Platform)
-				}
-				if matched {
-					found = true
-					fan := c.Fans[config.HwMon.Index].Config.HwMon
-					config.HwMon.PwmOutput = fan.PwmOutput
-					config.HwMon.RpmInput = fan.RpmInput
-					break
-				}
-			}
-			if !found {
-				ui.Fatal("Couldn't find hwmon device with platform '%s' for fan: %s", config.HwMon.Platform, config.ID)
+			err := hwmon.UpdateFanConfigFromHwMonControllers(controllers, &config)
+			if err != nil {
+				ui.Fatal("Couldn't update fan config from hwmon: %s", err)
 			}
 		}
 

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -20,7 +20,7 @@ type FanConfig struct {
 type HwMonFanConfig struct {
 	Platform      string `json:"platform"`
 	Index         int    `json:"index"`
-	Channel       int    `json:"channel"`
+	RpmChannel    int    `json:"rpmChannel"`
 	PwmChannel    int    `json:"pwmChannel"`
 	SysfsPath     string
 	RpmInputPath  string

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -18,10 +18,14 @@ type FanConfig struct {
 }
 
 type HwMonFanConfig struct {
-	Platform  string `json:"platform"`
-	Index     int    `json:"index"`
-	PwmOutput string
-	RpmInput  string
+	Platform      string `json:"platform"`
+	Index         int    `json:"index"`
+	Channel       int    `json:"channel"`
+	PwmChannel    int    `json:"pwmChannel"`
+	SysfsPath     string
+	RpmInputPath  string
+	PwmPath       string
+	PwmEnablePath string
 }
 
 type FileFanConfig struct {

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -3,11 +3,12 @@ package configuration
 import (
 	"errors"
 	"fmt"
+	"strings"
+
 	"github.com/looplab/tarjan"
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/markusressel/fan2go/internal/util"
 	"golang.org/x/exp/slices"
-	"strings"
 )
 
 func Validate(configPath string) error {
@@ -266,8 +267,17 @@ func validateFans(config *Configuration) error {
 		}
 
 		if fanConfig.HwMon != nil {
-			if fanConfig.HwMon.Index <= 0 {
+			if (fanConfig.HwMon.Index != 0 && fanConfig.HwMon.Channel != 0) || (fanConfig.HwMon.Index == 0 && fanConfig.HwMon.Channel == 0) {
+				return errors.New(fmt.Sprintf("Fan %s: must have one of index or channel, must be >= 1", fanConfig.ID))
+			}
+			if fanConfig.HwMon.Index < 0 {
 				return errors.New(fmt.Sprintf("Fan %s: invalid index, must be >= 1", fanConfig.ID))
+			}
+			if fanConfig.HwMon.Channel < 0 {
+				return errors.New(fmt.Sprintf("Fan %s: invalid channel, must be >= 1", fanConfig.ID))
+			}
+			if fanConfig.HwMon.PwmChannel < 0 {
+				return errors.New(fmt.Sprintf("Fan %s: invalid pwmChannel, must be >= 1", fanConfig.ID))
 			}
 		}
 

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -267,14 +267,14 @@ func validateFans(config *Configuration) error {
 		}
 
 		if fanConfig.HwMon != nil {
-			if (fanConfig.HwMon.Index != 0 && fanConfig.HwMon.Channel != 0) || (fanConfig.HwMon.Index == 0 && fanConfig.HwMon.Channel == 0) {
-				return errors.New(fmt.Sprintf("Fan %s: must have one of index or channel, must be >= 1", fanConfig.ID))
+			if (fanConfig.HwMon.Index != 0 && fanConfig.HwMon.RpmChannel != 0) || (fanConfig.HwMon.Index == 0 && fanConfig.HwMon.RpmChannel == 0) {
+				return errors.New(fmt.Sprintf("Fan %s: must have one of index or rpmChannel, must be >= 1", fanConfig.ID))
 			}
 			if fanConfig.HwMon.Index < 0 {
 				return errors.New(fmt.Sprintf("Fan %s: invalid index, must be >= 1", fanConfig.ID))
 			}
-			if fanConfig.HwMon.Channel < 0 {
-				return errors.New(fmt.Sprintf("Fan %s: invalid channel, must be >= 1", fanConfig.ID))
+			if fanConfig.HwMon.RpmChannel < 0 {
+				return errors.New(fmt.Sprintf("Fan %s: invalid rpmChannel, must be >= 1", fanConfig.ID))
 			}
 			if fanConfig.HwMon.PwmChannel < 0 {
 				return errors.New(fmt.Sprintf("Fan %s: invalid pwmChannel, must be >= 1", fanConfig.ID))

--- a/internal/configuration/validation_test.go
+++ b/internal/configuration/validation_test.go
@@ -454,7 +454,7 @@ func TestValidateFanHasIndexOrChannel(t *testing.T) {
 	err := validateConfig(&config, "")
 
 	// THEN
-	assert.EqualError(t, err, "Fan fan: must have one of index or channel, must be >= 1")
+	assert.EqualError(t, err, "Fan fan: must have one of index or rpmChannel, must be >= 1")
 }
 
 func TestValidateFanIndex(t *testing.T) {
@@ -505,7 +505,7 @@ func TestValidateFanChannel(t *testing.T) {
 				ID:    "fan",
 				Curve: "curve",
 				HwMon: &HwMonFanConfig{
-					Channel: -1,
+					RpmChannel: -1,
 				},
 			},
 		},
@@ -534,7 +534,7 @@ func TestValidateFanChannel(t *testing.T) {
 	err := validateConfig(&config, "")
 
 	// THEN
-	assert.EqualError(t, err, "Fan fan: invalid channel, must be >= 1")
+	assert.EqualError(t, err, "Fan fan: invalid rpmChannel, must be >= 1")
 }
 
 func TestValidateFanPwmChannel(t *testing.T) {
@@ -545,7 +545,7 @@ func TestValidateFanPwmChannel(t *testing.T) {
 				ID:    "fan",
 				Curve: "curve",
 				HwMon: &HwMonFanConfig{
-					Channel:    1,
+					RpmChannel: 1,
 					PwmChannel: -1,
 				},
 			},

--- a/internal/configuration/validation_test.go
+++ b/internal/configuration/validation_test.go
@@ -2,8 +2,9 @@ package configuration
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateDuplicateFanId(t *testing.T) {
@@ -416,4 +417,163 @@ func TestValidateDuplicateSensorId(t *testing.T) {
 
 	// THEN
 	assert.EqualError(t, err, fmt.Sprintf("Duplicate sensor id detected: %s", sensorId))
+}
+
+func TestValidateFanHasIndexOrChannel(t *testing.T) {
+	// GIVEN
+	config := Configuration{
+		Fans: []FanConfig{
+			{
+				ID:    "fan",
+				Curve: "curve",
+				HwMon: &HwMonFanConfig{},
+			},
+		},
+		Curves: []CurveConfig{
+			{
+				ID: "curve",
+				Linear: &LinearCurveConfig{
+					Sensor: "sensor",
+					Min:    0,
+					Max:    100,
+				},
+				Function: nil,
+			},
+		},
+		Sensors: []SensorConfig{
+			{
+				ID: "sensor",
+				File: &FileSensorConfig{
+					Path: "",
+				},
+			},
+		},
+	}
+
+	// WHEN
+	err := validateConfig(&config, "")
+
+	// THEN
+	assert.EqualError(t, err, "Fan fan: must have one of index or channel, must be >= 1")
+}
+
+func TestValidateFanIndex(t *testing.T) {
+	// GIVEN
+	config := Configuration{
+		Fans: []FanConfig{
+			{
+				ID:    "fan",
+				Curve: "curve",
+				HwMon: &HwMonFanConfig{
+					Index: -1,
+				},
+			},
+		},
+		Curves: []CurveConfig{
+			{
+				ID: "curve",
+				Linear: &LinearCurveConfig{
+					Sensor: "sensor",
+					Min:    0,
+					Max:    100,
+				},
+				Function: nil,
+			},
+		},
+		Sensors: []SensorConfig{
+			{
+				ID: "sensor",
+				File: &FileSensorConfig{
+					Path: "",
+				},
+			},
+		},
+	}
+
+	// WHEN
+	err := validateConfig(&config, "")
+
+	// THEN
+	assert.EqualError(t, err, "Fan fan: invalid index, must be >= 1")
+}
+
+func TestValidateFanChannel(t *testing.T) {
+	// GIVEN
+	config := Configuration{
+		Fans: []FanConfig{
+			{
+				ID:    "fan",
+				Curve: "curve",
+				HwMon: &HwMonFanConfig{
+					Channel: -1,
+				},
+			},
+		},
+		Curves: []CurveConfig{
+			{
+				ID: "curve",
+				Linear: &LinearCurveConfig{
+					Sensor: "sensor",
+					Min:    0,
+					Max:    100,
+				},
+				Function: nil,
+			},
+		},
+		Sensors: []SensorConfig{
+			{
+				ID: "sensor",
+				File: &FileSensorConfig{
+					Path: "",
+				},
+			},
+		},
+	}
+
+	// WHEN
+	err := validateConfig(&config, "")
+
+	// THEN
+	assert.EqualError(t, err, "Fan fan: invalid channel, must be >= 1")
+}
+
+func TestValidateFanPwmChannel(t *testing.T) {
+	// GIVEN
+	config := Configuration{
+		Fans: []FanConfig{
+			{
+				ID:    "fan",
+				Curve: "curve",
+				HwMon: &HwMonFanConfig{
+					Channel:    1,
+					PwmChannel: -1,
+				},
+			},
+		},
+		Curves: []CurveConfig{
+			{
+				ID: "curve",
+				Linear: &LinearCurveConfig{
+					Sensor: "sensor",
+					Min:    0,
+					Max:    100,
+				},
+				Function: nil,
+			},
+		},
+		Sensors: []SensorConfig{
+			{
+				ID: "sensor",
+				File: &FileSensorConfig{
+					Path: "",
+				},
+			},
+		},
+	}
+
+	// WHEN
+	err := validateConfig(&config, "")
+
+	// THEN
+	assert.EqualError(t, err, "Fan fan: invalid pwmChannel, must be >= 1")
 }

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1,15 +1,16 @@
 package controller
 
 import (
+	"sort"
+	"testing"
+	"time"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/curves"
 	"github.com/markusressel/fan2go/internal/fans"
 	"github.com/markusressel/fan2go/internal/sensors"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/stretchr/testify/assert"
-	"sort"
-	"testing"
-	"time"
 )
 
 type MockSensor struct {
@@ -231,10 +232,8 @@ func CreateFan(neverStop bool, curveData map[int]float64, startPwm *int) (fan fa
 		Config: configuration.FanConfig{
 			ID: "fan1",
 			HwMon: &configuration.HwMonFanConfig{
-				Platform:  "platform",
-				Index:     1,
-				PwmOutput: "fan1_output",
-				RpmInput:  "fan1_rpm",
+				Platform: "platform",
+				Index:    1,
 			},
 			NeverStop: neverStop,
 			Curve:     "curve",

--- a/internal/hwmon/hwmon.go
+++ b/internal/hwmon/hwmon.go
@@ -3,6 +3,7 @@ package hwmon
 import (
 	"errors"
 	"fmt"
+	"github.com/markusressel/fan2go/internal/ui"
 	"io/ioutil"
 	"path"
 	"path/filepath"
@@ -164,6 +165,7 @@ func GetFans(chip gosensors.Chip) []fans.HwMonFan {
 			var channel int
 			_, err := fmt.Sscanf(feature.Name, "fan%d", &channel)
 			if err != nil {
+				ui.Warning("No channel found for '%s', ignoring.", feature.Name)
 				continue
 			}
 
@@ -198,7 +200,7 @@ func GetFans(chip gosensors.Chip) []fans.HwMonFan {
 					MaxPwm: &max,
 					HwMon: &configuration.HwMonFanConfig{
 						Index:      len(result) + 1,
-						Channel:    channel,
+						RpmChannel: channel,
 						PwmChannel: channel,
 						SysfsPath:  chip.Path,
 					},
@@ -295,11 +297,11 @@ func UpdateFanConfigFromHwMonControllers(controllers []*HwMonController, config 
 			if config.HwMon.Index > 0 && controllerConfig.Index != config.HwMon.Index {
 				continue
 			}
-			if config.HwMon.Channel > 0 && controllerConfig.Channel != config.HwMon.Channel {
+			if config.HwMon.RpmChannel > 0 && controllerConfig.RpmChannel != config.HwMon.RpmChannel {
 				continue
 			}
 			config.HwMon.Index = controllerConfig.Index
-			config.HwMon.Channel = controllerConfig.Channel
+			config.HwMon.RpmChannel = controllerConfig.RpmChannel
 			config.HwMon.SysfsPath = controllerConfig.SysfsPath
 			if config.HwMon.PwmChannel == 0 {
 				config.HwMon.PwmChannel = controllerConfig.PwmChannel
@@ -312,7 +314,7 @@ func UpdateFanConfigFromHwMonControllers(controllers []*HwMonController, config 
 }
 
 func setFanConfigPaths(config *configuration.HwMonFanConfig) {
-	config.RpmInputPath = path.Join(config.SysfsPath, fmt.Sprintf("fan%d_input", config.Channel))
+	config.RpmInputPath = path.Join(config.SysfsPath, fmt.Sprintf("fan%d_input", config.RpmChannel))
 	config.PwmPath = path.Join(config.SysfsPath, fmt.Sprintf("pwm%d", config.PwmChannel))
 	config.PwmEnablePath = path.Join(config.SysfsPath, fmt.Sprintf("pwm%d_enable", config.PwmChannel))
 }

--- a/internal/hwmon/hwmon_test.go
+++ b/internal/hwmon/hwmon_test.go
@@ -2,9 +2,12 @@ package hwmon
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/markusressel/fan2go/internal/configuration"
+	"github.com/markusressel/fan2go/internal/fans"
 	"github.com/md14454/gosensors"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestComputeIdentifierIsa(t *testing.T) {
@@ -75,4 +78,156 @@ func TestFindPlatform(t *testing.T) {
 
 	// THEN
 	assert.Equal(t, "", platform)
+}
+
+func TestUpdateFanConfigFromHwMonControllers(t *testing.T) {
+	var tests = []struct {
+		tn            string
+		hwMonConfigs  []configuration.HwMonFanConfig
+		hwMonPlatform string
+		configConfig  configuration.HwMonFanConfig
+		wantConfig    *configuration.HwMonFanConfig
+		wantErr       string
+	}{{
+		tn: "index config",
+		hwMonConfigs: []configuration.HwMonFanConfig{
+			{
+				Index:      1,
+				Channel:    2,
+				PwmChannel: 2,
+				SysfsPath:  "/sys/hwmon1",
+			},
+		},
+		configConfig: configuration.HwMonFanConfig{
+			Index: 1,
+		},
+		wantConfig: &configuration.HwMonFanConfig{
+			Index:         1,
+			Channel:       2,
+			PwmChannel:    2,
+			SysfsPath:     "/sys/hwmon1",
+			RpmInputPath:  "/sys/hwmon1/fan2_input",
+			PwmPath:       "/sys/hwmon1/pwm2",
+			PwmEnablePath: "/sys/hwmon1/pwm2_enable",
+		},
+	}, {
+		tn: "channel config",
+		hwMonConfigs: []configuration.HwMonFanConfig{
+			{
+				Index:      1,
+				Channel:    2,
+				PwmChannel: 2,
+				SysfsPath:  "/sys/hwmon1",
+			},
+		},
+		configConfig: configuration.HwMonFanConfig{
+			Channel: 2,
+		},
+		wantConfig: &configuration.HwMonFanConfig{
+			Index:         1,
+			Channel:       2,
+			PwmChannel:    2,
+			SysfsPath:     "/sys/hwmon1",
+			RpmInputPath:  "/sys/hwmon1/fan2_input",
+			PwmPath:       "/sys/hwmon1/pwm2",
+			PwmEnablePath: "/sys/hwmon1/pwm2_enable",
+		},
+	}, {
+		tn: "pwm channel config",
+		hwMonConfigs: []configuration.HwMonFanConfig{
+			{
+				Index:      1,
+				Channel:    2,
+				PwmChannel: 2,
+				SysfsPath:  "/sys/hwmon1",
+			},
+		},
+		configConfig: configuration.HwMonFanConfig{
+			Channel:    2,
+			PwmChannel: 3,
+		},
+		wantConfig: &configuration.HwMonFanConfig{
+			Index:         1,
+			Channel:       2,
+			PwmChannel:    3,
+			SysfsPath:     "/sys/hwmon1",
+			RpmInputPath:  "/sys/hwmon1/fan2_input",
+			PwmPath:       "/sys/hwmon1/pwm3",
+			PwmEnablePath: "/sys/hwmon1/pwm3_enable",
+		},
+	}, {
+		tn: "no hwmon fans",
+		configConfig: configuration.HwMonFanConfig{
+			Index: 1,
+		},
+		wantErr: "No hwmon fan matched fan config",
+	}, {
+		tn: "no matching index",
+		hwMonConfigs: []configuration.HwMonFanConfig{
+			{
+				Index: 2,
+			},
+		},
+		configConfig: configuration.HwMonFanConfig{
+			Index: 1,
+		},
+		wantErr: "No hwmon fan matched fan config",
+	}, {
+		tn: "no matching platform",
+		hwMonConfigs: []configuration.HwMonFanConfig{
+			{
+				Index: 1,
+			},
+		},
+		hwMonPlatform: "abc",
+		configConfig: configuration.HwMonFanConfig{
+			Index: 1,
+		},
+		wantErr: "No hwmon fan matched fan config",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.tn, func(t *testing.T) {
+			// GIVEN
+			fanSlice := []fans.HwMonFan{}
+			for _, c := range tt.hwMonConfigs {
+				fanSlice = append(fanSlice, fans.HwMonFan{
+					Config: configuration.FanConfig{
+						HwMon: &c,
+					},
+				})
+			}
+			if tt.hwMonPlatform == "" {
+				tt.hwMonPlatform = "platform"
+			}
+			controllers := []*HwMonController{
+				{
+					Platform: tt.hwMonPlatform,
+					Fans:     fanSlice,
+				},
+			}
+			if tt.configConfig.Platform == "" {
+				tt.configConfig.Platform = "platform"
+			}
+			config := configuration.FanConfig{
+				HwMon: &tt.configConfig,
+			}
+
+			// WHEN
+			err := UpdateFanConfigFromHwMonControllers(controllers, &config)
+
+			// THEN
+			if tt.wantConfig != nil {
+				if tt.wantConfig.Platform == "" {
+					tt.wantConfig.Platform = "platform"
+				}
+				assert.Equal(t, tt.wantConfig, config.HwMon)
+			}
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/hwmon/hwmon_test.go
+++ b/internal/hwmon/hwmon_test.go
@@ -93,7 +93,7 @@ func TestUpdateFanConfigFromHwMonControllers(t *testing.T) {
 		hwMonConfigs: []configuration.HwMonFanConfig{
 			{
 				Index:      1,
-				Channel:    2,
+				RpmChannel: 2,
 				PwmChannel: 2,
 				SysfsPath:  "/sys/hwmon1",
 			},
@@ -103,7 +103,7 @@ func TestUpdateFanConfigFromHwMonControllers(t *testing.T) {
 		},
 		wantConfig: &configuration.HwMonFanConfig{
 			Index:         1,
-			Channel:       2,
+			RpmChannel:    2,
 			PwmChannel:    2,
 			SysfsPath:     "/sys/hwmon1",
 			RpmInputPath:  "/sys/hwmon1/fan2_input",
@@ -115,17 +115,17 @@ func TestUpdateFanConfigFromHwMonControllers(t *testing.T) {
 		hwMonConfigs: []configuration.HwMonFanConfig{
 			{
 				Index:      1,
-				Channel:    2,
+				RpmChannel: 2,
 				PwmChannel: 2,
 				SysfsPath:  "/sys/hwmon1",
 			},
 		},
 		configConfig: configuration.HwMonFanConfig{
-			Channel: 2,
+			RpmChannel: 2,
 		},
 		wantConfig: &configuration.HwMonFanConfig{
 			Index:         1,
-			Channel:       2,
+			RpmChannel:    2,
 			PwmChannel:    2,
 			SysfsPath:     "/sys/hwmon1",
 			RpmInputPath:  "/sys/hwmon1/fan2_input",
@@ -137,18 +137,18 @@ func TestUpdateFanConfigFromHwMonControllers(t *testing.T) {
 		hwMonConfigs: []configuration.HwMonFanConfig{
 			{
 				Index:      1,
-				Channel:    2,
+				RpmChannel: 2,
 				PwmChannel: 2,
 				SysfsPath:  "/sys/hwmon1",
 			},
 		},
 		configConfig: configuration.HwMonFanConfig{
-			Channel:    2,
+			RpmChannel: 2,
 			PwmChannel: 3,
 		},
 		wantConfig: &configuration.HwMonFanConfig{
 			Index:         1,
-			Channel:       2,
+			RpmChannel:    2,
 			PwmChannel:    3,
 			SysfsPath:     "/sys/hwmon1",
 			RpmInputPath:  "/sys/hwmon1/fan2_input",

--- a/internal/persistence/persistence_test.go
+++ b/internal/persistence/persistence_test.go
@@ -1,11 +1,12 @@
 package persistence
 
 import (
+	"testing"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/fans"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (
@@ -114,10 +115,8 @@ func createFan(neverStop bool, curveData map[int]float64) (fan fans.Fan, err err
 		Config: configuration.FanConfig{
 			ID: "fan1",
 			HwMon: &configuration.HwMonFanConfig{
-				Platform:  "platform",
-				Index:     1,
-				PwmOutput: "fan1_output",
-				RpmInput:  "fan1_rpm",
+				Platform: "platform",
+				Index:    1,
 			},
 			NeverStop: neverStop,
 			Curve:     "curve",


### PR DESCRIPTION
This patch reworks HwMon fans to better handle systems with discontinuous fan and pwm channels. For example, a system with "fan1, fan2, fan7" and "pwm1, pwm7" is now handled relatively well. All fans will be listed by the `detect` command, "pwm1" will be associated with "fan1" by default based on the channel number, and a config can be used to map "fan2" to "pwm1" (if a pwm channel controls more than one fan, for example).

This patch _does_ include a breaking change by reinterpreting the "index" config field of `HwMonFanConfig` as a hwmon channel number rather than as the hwmon enumeration index.

Fixes #187