### PR TITLE
Fix autoconfigure for weird PWMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,6 @@ Flags:
   -v, --verbose         More verbose output
 
 Use "fan2go [command] --help" for more information about a command.
-
 > sudo fan2go
 ```
 
@@ -614,6 +613,10 @@ configuration.
 
 To reduce the risk of runnin the whole system on low fan speeds for such a long period of time, you can force fan2go to
 initialize only one fan at a time, using the `runFanInitializationInParallel: false` config option.
+
+Some PWM controllers or fans may require more time to react to PWM changes. If fan2go is failing to characterize a fan,
+you can try increasing the fan response delay by passing `--fan-response-delay <seconds>` to the `fan init` command or
+by setting `fanResponseDelay` in the config. The default value is 2 seconds.
 
 ## Monitoring
 

--- a/cmd/fan/init.go
+++ b/cmd/fan/init.go
@@ -7,6 +7,7 @@ import (
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 var initCmd = &cobra.Command{
@@ -59,5 +60,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.Flags().IntP("fan-response-delay", "e", 2, "Delay in seconds to wait before checking that a fan has responded to a control change")
+	_ = viper.BindPFlag("FanResponseDelay", initCmd.Flags().Lookup("fan-response-delay"))
 	Command.AddCommand(initCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pterm/pterm/putils"
 	"os"
+
+	"github.com/pterm/pterm/putils"
 
 	"github.com/markusressel/fan2go/cmd/config"
 	"github.com/markusressel/fan2go/cmd/curve"

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -8,6 +8,10 @@ runFanInitializationInParallel: false
 # Note: This parameter is only used for initial analysis of fan curve
 #       and has no effect during normal operation
 maxRpmDiffForSettledFan: 10
+# The time in seconds to wait before checking that a fan has responded to a control change
+# Note: This parameter is only used for initial analysis of fan curve
+#       and has no effect during normal operation
+fanResponseDelay: 10
 
 # The rate to poll temperature sensors at
 tempSensorPollingRate: 200ms

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -11,7 +11,7 @@ maxRpmDiffForSettledFan: 10
 # The time in seconds to wait before checking that a fan has responded to a control change
 # Note: This parameter is only used for initial analysis of fan curve
 #       and has no effect during normal operation
-fanResponseDelay: 10
+fanResponseDelay: 2
 
 # The rate to poll temperature sensors at
 tempSensorPollingRate: 200ms

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -1,11 +1,12 @@
 package configuration
 
 import (
+	"os"
+	"time"
+
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-	"os"
-	"time"
 )
 
 type Configuration struct {
@@ -13,6 +14,7 @@ type Configuration struct {
 
 	RunFanInitializationInParallel bool    `json:"runFanInitializationInParallel"`
 	MaxRpmDiffForSettledFan        float64 `json:"maxRpmDiffForSettledFan"`
+	FanResponseDelay               int     `json:"fanResponseDelay"`
 
 	TempSensorPollingRate time.Duration `json:"tempSensorPollingRate"`
 	TempRollingWindowSize int           `json:"tempRollingWindowSize"`
@@ -62,6 +64,7 @@ func setDefaultValues() {
 	viper.SetDefault("dbpath", "/etc/fan2go/fan2go.db")
 	viper.SetDefault("RunFanInitializationInParallel", true)
 	viper.SetDefault("MaxRpmDiffForSettledFan", 10.0)
+	viper.SetDefault("FanResponseDelay", 2)
 	viper.SetDefault("TempSensorPollingRate", 200*time.Millisecond)
 	viper.SetDefault("TempRollingWindowSize", 10)
 	viper.SetDefault("RpmPollingRate", 1*time.Second)

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -467,6 +467,6 @@ func TestFanController_UpdateFanSpeed_FanCurveGaps(t *testing.T) {
 	// THEN
 	assert.Equal(t, 54, targetPwm)
 
-	closestTarget := controller.mapToClosestDistinct(targetPwm)
-	assert.Equal(t, 50, closestTarget)
+	closestTarget := controller.findClosestDistinctTarget(targetPwm)
+	assert.Equal(t, 58, closestTarget)
 }


### PR DESCRIPTION
This patch fixes fan autoconfiguration for weird PWMs that have non-1:1 value maps. In particular, it fixes the construction of the RPM curve data to properly use the PWM value map computed just before.

This patch also extends a few sleeps to give slow PWMs/fans more time to react to requested changes.