### PR TITLE
Raise default MaxRpmDiffForSettledFan

### DIFF
--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -7,7 +7,7 @@ runFanInitializationInParallel: false
 # consider a fan speed "settled"
 # Note: This parameter is only used for initial analysis of fan curve
 #       and has no effect during normal operation
-maxRpmDiffForSettledFan: 10
+maxRpmDiffForSettledFan: 20
 # The time in seconds to wait before checking that a fan has responded to a control change
 # Note: This parameter is only used for initial analysis of fan curve
 #       and has no effect during normal operation

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -63,7 +63,7 @@ func InitConfig(cfgFile string) {
 func setDefaultValues() {
 	viper.SetDefault("dbpath", "/etc/fan2go/fan2go.db")
 	viper.SetDefault("RunFanInitializationInParallel", true)
-	viper.SetDefault("MaxRpmDiffForSettledFan", 10.0)
+	viper.SetDefault("MaxRpmDiffForSettledFan", 20.0)
 	viper.SetDefault("FanResponseDelay", 2)
 	viper.SetDefault("TempSensorPollingRate", 200*time.Millisecond)
 	viper.SetDefault("TempRollingWindowSize", 10)


### PR DESCRIPTION
On my system this was stabilizing around 12-13 so init was stuck, leading to some time spent looking under the hood. I think it should be harmless to raise this a bit and maybe save someone else the trouble.