### PR TITLE
introduce "bypassPwmMap" option to not calculate a pwm map for a fan

### DIFF
--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -11,6 +11,7 @@ type FanConfig struct {
 	// MaxPwm defines the highest PWM value that yields an RPM increase
 	MaxPwm           *int                    `json:"maxPwm,omitempty"`
 	PwmMap           *map[int]int            `json:"pwmMap,omitempty"`
+	BypassPwmMap     *bool                   `json:"bypassPwmMap,omitempty"`
 	Curve            string                  `json:"curve"`
 	ControlAlgorithm *ControlAlgorithmConfig `json:"controlAlgorithm,omitempty"`
 	HwMon            *HwMonFanConfig         `json:"hwMon,omitempty"`

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/markusressel/fan2go/internal/control_loop"
 	"math"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/markusressel/fan2go/internal/control_loop"
 
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/curves"
@@ -579,19 +580,40 @@ func (f *DefaultFanController) computePwmMap() (err error) {
 
 	switch f := f.fan.(type) {
 	case *fans.HwMonFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
+		if f.Config.BypassPwmMap != nil && *f.Config.BypassPwmMap {
+			// if the user decides to not make use of the pwm mapping, use a default 0-0 to 255-255 map
+			defaultPwmMap := util.InterpolateLinearlyInt(&map[int]int{0: 0, 255: 255}, 0, 255)
+			configOverride = &defaultPwmMap
+		} else {
+			// if the user gave an explicit pwm map to use, use it
+			c := f.Config.PwmMap
+			if c != nil {
+				configOverride = c
+			}
 		}
 	case *fans.CmdFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
+		if f.Config.BypassPwmMap != nil && *f.Config.BypassPwmMap {
+			// if the user decides to not make use of the pwm mapping, use a default 0-0 to 255-255 map
+			defaultPwmMap := util.InterpolateLinearlyInt(&map[int]int{0: 0, 255: 255}, 0, 255)
+			configOverride = &defaultPwmMap
+		} else {
+			// if the user gave an explicit pwm map to use, use it
+			c := f.Config.PwmMap
+			if c != nil {
+				configOverride = c
+			}
 		}
 	case *fans.FileFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
+		if f.Config.BypassPwmMap != nil && *f.Config.BypassPwmMap {
+			// if the user decides to not make use of the pwm mapping, use a default 0-0 to 255-255 map
+			defaultPwmMap := util.InterpolateLinearlyInt(&map[int]int{0: 0, 255: 255}, 0, 255)
+			configOverride = &defaultPwmMap
+		} else {
+			// if the user gave an explicit pwm map to use, use it
+			c := f.Config.PwmMap
+			if c != nil {
+				configOverride = c
+			}
 		}
 	default:
 		// if type is other than above


### PR DESCRIPTION
Some fan controllers (such as my very new nct6687) take a good second between setting an rpm value and it reflecting back on read.

This either breaks the fan init sequence (see #358) or, if the delay is increased (in this case around 1s), makes it insufferably long.

This PR introduces a config option for a fan to bypass the pwm map calculation. During fan init, if this flag is set, a default 0=0..255=255 map is used as a configOverride.