### PR TITLE
Feature/add config option to selectively configure sanity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,10 @@ fans:
     # (Optional) Configuration options for sanity checks
     sanityCheck:
       # (Optional) Control the behavior of the "pwmValueChangedByThirdParty" sanity check
+      # THis check is used to detect if the PWM value of a fan has changed between two consecutive
+      # control loop cycles, which is usually an indication that an external program is trying to control the fan
+      # at the same time as fan2go. This can lead to unexpected behavior and is usually not desired, so 
+      # fan2go will log a warning if this happens.
       pwmValueChangedByThirdParty:
         # (Optional) Whether to enable this check or not
         enabled: true

--- a/README.md
+++ b/README.md
@@ -250,13 +250,19 @@ fans:
     # (f.ex. off, low, high). If not set manually, fan2go will try to compute this mapping
     # automatically during fan initialization. This process is not perfect though and may
     # result in suboptimal fan control.
-    # Note: The mapping must be strictly monotonically increasing and its Key-Set should cover the full
-    # range of values from 0 to 255. If keys are missing, fan2go will select a key that most closely
-    # matches the required target value during operation.
+    # Note: The values of the mapping must be strictly monotonically increasing. The Key-Set must 
+    # be in [0..255] but may omit values. If keys are missing, fan2go will select a key that most 
+    # closely matches the required target value (computed by the referenced curve) during operation.
     pwmMap:
       0: 0
       64: 128
       192: 255
+    # (Optional) Configuration options for sanity checks
+    sanityCheck:
+      # (Optional) Control the behavior of the "pwmValueChangedByThirdParty" sanity check
+      pwmValueChangedByThirdParty:
+        # (Optional) Whether to enable this check or not
+        enabled: true
 ```
 
 ### Sensors

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -76,13 +76,19 @@ fans:
     # (f.ex. off, low, high). If not set manually, fan2go will try to compute this mapping
     # automatically during fan initialization. This process is not perfect though and may
     # result in suboptimal fan control.
-    # Note: The mapping must be strictly monotonically increasing and its Key-Set should cover the full
-    # range of values from 0 to 255. If keys are missing, fan2go will select a key that most closely
-    # matches the required target value during operation.
+    # Note: The values of the mapping must be strictly monotonically increasing. The Key-Set must
+    # be in [0..255] but may omit values. If keys are missing, fan2go will select a key that most
+    # closely matches the required target value (computed by the referenced curve) during operation.
     pwmMap:
       0: 0
       64: 128
       192: 255
+    # (Optional) Configuration options for sanity checks
+    sanityCheck:
+      # (Optional) Control the behavior of the "pwmValueChangedByThirdParty" sanity check
+      pwmValueChangedByThirdParty:
+        # (Optional) Whether to enable this check or not
+        enabled: true
 
   - id: in_front
     hwmon:

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -86,6 +86,10 @@ fans:
     # (Optional) Configuration options for sanity checks
     sanityCheck:
       # (Optional) Control the behavior of the "pwmValueChangedByThirdParty" sanity check
+      # THis check is used to detect if the PWM value of a fan has changed between two consecutive
+      # control loop cycles, which is usually an indication that an external program is trying to control the fan
+      # at the same time as fan2go. This can lead to unexpected behavior and is usually not desired, so
+      # fan2go will log a warning if this happens.
       pwmValueChangedByThirdParty:
         # (Optional) Whether to enable this check or not
         enabled: true

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -65,7 +65,7 @@ type SanityCheckConfig struct {
 }
 
 type PwmValueChangedByThirdPartyConfig struct {
-	Enabled *bool `json:"enabled,omitempty,default=true"`
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 type HwMonFanConfig struct {

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -18,6 +18,8 @@ type FanConfig struct {
 	Curve string `json:"curve"`
 	// ControlAlgorithm defines how the curve target is applied to the fan.
 	ControlAlgorithm *ControlAlgorithmConfig `json:"controlAlgorithm,omitempty"`
+	// SanityCheck defines Configuration options for sanity checks
+	SanityCheck *SanityCheckConfig `json:"sanityCheck,omitempty"`
 	// HwMon, File and Cmd are the different ways to configure the respective fan types.
 	HwMon *HwMonFanConfig `json:"hwMon,omitempty"`
 	File  *FileFanConfig  `json:"file,omitempty"`
@@ -55,6 +57,15 @@ type PidControlAlgorithmConfig struct {
 	I float64 `json:"i"`
 	// D is the derivative gain.
 	D float64 `json:"d"`
+}
+
+type SanityCheckConfig struct {
+	// Enabled defines whether the sanity check is enabled.
+	PwmValueChangedByThirdParty *PwmValueChangedByThirdPartyConfig `json:"pwmValueChangedByThirdParty,omitempty"`
+}
+
+type PwmValueChangedByThirdPartyConfig struct {
+	Enabled *bool `json:"enabled,omitempty,default=true"`
 }
 
 type HwMonFanConfig struct {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -563,7 +563,7 @@ func (f *DefaultFanController) ensureNoThirdPartyIsMessingWithUs() {
 		if currentPwm, err := f.fan.GetPwm(); err == nil {
 			if currentPwm != expectedReportedPwm {
 				f.stats.UnexpectedPwmValueCount += 1
-				ui.Warning("PWM of %s was changed by third party! Last set PWM value was: %d, expected reported pwm is %d but is now: %d",
+				ui.Warning("PWM of %s was changed by third party! Last set PWM value was '%d', expected reported pwm '%d' but was '%d'",
 					f.fan.GetId(), pwmMappedValue, expectedReportedPwm, currentPwm)
 			}
 		}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -163,6 +163,23 @@ func (fan MockFan) ShouldNeverStop() bool {
 	return fan.shouldNeverStop
 }
 
+func (fan MockFan) GetConfig() configuration.FanConfig {
+	startPwm := 0
+	maxPwm := fans.MaxPwmValue
+	return configuration.FanConfig{
+		ID:        fan.ID,
+		Curve:     fan.curveId,
+		NeverStop: fan.shouldNeverStop,
+		StartPwm:  &startPwm,
+		MinPwm:    &fan.MinPWM,
+		MaxPwm:    &maxPwm,
+		PwmMap:    fan.PwmMap,
+		HwMon:     nil, // Not used in this mock
+		File:      nil, // Not used in this mock
+		Cmd:       nil, // Not used in this mock
+	}
+}
+
 func (fan MockFan) Supports(feature fans.FeatureFlag) bool {
 	return true
 }
@@ -861,6 +878,23 @@ func (fan MockFanWithOffsetPwm) GetCurveId() string {
 
 func (fan MockFanWithOffsetPwm) ShouldNeverStop() bool {
 	return fan.shouldNeverStop
+}
+
+func (fan MockFanWithOffsetPwm) GetConfig() configuration.FanConfig {
+	startPwm := 0
+	maxPwm := fans.MaxPwmValue
+	return configuration.FanConfig{
+		ID:        fan.ID,
+		Curve:     fan.curveId,
+		NeverStop: fan.shouldNeverStop,
+		StartPwm:  &startPwm,
+		MinPwm:    &fan.MinPWM,
+		MaxPwm:    &maxPwm,
+		PwmMap:    fan.PwmMap,
+		HwMon:     nil, // Not used in this mock
+		File:      nil, // Not used in this mock
+		Cmd:       nil, // Not used in this mock
+	}
 }
 
 func (fan MockFanWithOffsetPwm) Supports(feature fans.FeatureFlag) bool {

--- a/internal/fans/cmd.go
+++ b/internal/fans/cmd.go
@@ -149,6 +149,10 @@ func (fan *CmdFan) IsPwmAuto() (bool, error) {
 	return true, nil
 }
 
+func (fan *CmdFan) GetConfig() configuration.FanConfig {
+	return fan.Config
+}
+
 func (fan *CmdFan) Supports(feature FeatureFlag) bool {
 	switch feature {
 	case FeatureControlMode:

--- a/internal/fans/common.go
+++ b/internal/fans/common.go
@@ -80,6 +80,8 @@ type Fan interface {
 	// IsPwmAuto indicates whether this fan is in "Auto" mode
 	IsPwmAuto() (bool, error)
 
+	GetConfig() configuration.FanConfig
+
 	Supports(feature FeatureFlag) bool
 }
 

--- a/internal/fans/file.go
+++ b/internal/fans/file.go
@@ -158,6 +158,10 @@ func (fan *FileFan) IsPwmAuto() (bool, error) {
 	return true, nil
 }
 
+func (fan *FileFan) GetConfig() configuration.FanConfig {
+	return fan.Config
+}
+
 func (fan *FileFan) Supports(feature FeatureFlag) bool {
 	switch feature {
 	case FeatureControlMode:

--- a/internal/fans/hwmon.go
+++ b/internal/fans/hwmon.go
@@ -179,6 +179,10 @@ func (fan *HwMonFan) SetPwmEnabled(value ControlMode) (err error) {
 	return err
 }
 
+func (fan *HwMonFan) GetConfig() configuration.FanConfig {
+	return fan.Config
+}
+
 func (fan *HwMonFan) Supports(feature FeatureFlag) bool {
 	switch feature {
 	case FeatureControlMode:


### PR DESCRIPTION
This PR adds the ability to selectively (per fan) change the configuration of sanity checks which are usually enabled by default. 

One usecase that I know of for this is to disable the "changed by third party" check. For fans that don't report the change in PWM value immediately, this sanity check results in a lot of log spam. Even though the detection is correct, it is not helpful as it cannot be easily fixed, since its caused by the driver implementation of the specific fan. In this case turning off this sanity check for the relevant fan avoids log spam.

The relevant config is:

```yaml
fans:
  - id: cpu
    ...
    sanityCheck:
      # (Optional) Control the behavior of the "pwmValueChangedByThirdParty" sanity check
      # THis check is used to detect if the PWM value of a fan has changed between two consecutive
      # control loop cycles, which is usually an indication that an external program is trying to control the fan
      # at the same time as fan2go. This can lead to unexpected behavior and is usually not desired, so
      # fan2go will log a warning if this happens.
      pwmValueChangedByThirdParty:
        # (Optional) Whether to enable this check or not
        enabled: false
```


See also #196 #161 #148