### PR TITLE
Feature/improve channel detection

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -79,6 +79,17 @@ var detectCmd = &cobra.Command{
 
 			var fanRows [][]string
 			for _, fan := range fanSlice {
+
+				pwmChannelText := "N/A"
+				if fan.Config.HwMon != nil && fan.Config.HwMon.PwmChannel >= 0 {
+					pwmChannelText = strconv.Itoa(fan.Config.HwMon.PwmChannel)
+				}
+
+				rpmChannelText := "N/A"
+				if fan.Config.HwMon != nil && fan.Config.HwMon.RpmChannel >= 0 {
+					rpmChannelText = strconv.Itoa(fan.Config.HwMon.RpmChannel)
+				}
+
 				pwmText := "N/A"
 				pwm, err := fan.GetPwm()
 				if err == nil {
@@ -101,10 +112,10 @@ var detectCmd = &cobra.Command{
 					}
 				}
 				fanRows = append(fanRows, []string{
-					"", strconv.Itoa(fan.Index), strconv.Itoa(fan.Config.HwMon.RpmChannel), fan.Label, rpmText, pwmText, fmt.Sprintf("%v", controlModeText),
+					"", strconv.Itoa(fan.Index), pwmChannelText, rpmChannelText, fan.Label, rpmText, pwmText, fmt.Sprintf("%v", controlModeText),
 				})
 			}
-			var fanHeaders = []string{"Fans   ", "Index", "Channel", "Label", "RPM", "PWM", "Mode"}
+			var fanHeaders = []string{"Fans   ", "Index", "PWM Channel", "RPM Channel", "Label", "RPM", "PWM", "Mode"}
 
 			fanTable := table.Table{
 				Headers: fanHeaders,

--- a/internal/hwmon/hwmon.go
+++ b/internal/hwmon/hwmon.go
@@ -151,7 +151,8 @@ func GetTempSensors(chip gosensors.Chip) map[int]*sensors.HwmonSensor {
 }
 
 var (
-	FeatureTypePwm gosensors.FeatureType = 7
+	FeatureTypePwm        gosensors.FeatureType    = 7
+	SubFeatureTypeFanMode gosensors.SubFeatureType = 1920
 )
 
 func GetFans(chip gosensors.Chip) []fans.HwMonFan {
@@ -184,16 +185,25 @@ func GetFans(chip gosensors.Chip) []fans.HwMonFan {
 			continue
 		}
 
-		if rpmChannel == -1 && pwmChannel == -1 {
+		if pwmChannel == -1 && rpmChannel == -1 {
 			ui.Warning("No rpmChannel or pwmChannel found for '%s', ignoring.", feature.Name)
 			continue
 		}
 
 		subfeatures := feature.GetSubFeatures()
+
+		modeSubFeature := getSubFeature(subfeatures, SubFeatureTypeFanMode)
+		if modeSubFeature != nil {
+			mode := modeSubFeature.GetValue()
+			ui.Debug("Found fan mode %d for feature '%s'", mode, feature.Name)
+		}
+
 		rpmAverage := 0.0
 		inputSubFeature := getSubFeature(subfeatures, gosensors.SubFeatureTypeFanInput)
 		if inputSubFeature != nil {
 			rpmAverage = inputSubFeature.GetValue()
+		} else {
+			rpmChannel = -1
 		}
 
 		max := -1


### PR DESCRIPTION
Improves the hwmon device detection by looking for both `pwm` and `fan` feature types (instead of only `fan`).

```
$ ./bin/fan2go detect
=========== hwmon: ============

> Platform: asus_custom_fan_curve-isa-000a
  Fans     Index  PWM Channel  RPM Channel  Label        RPM  PWM  Mode
           1      1            N/A          hwmon6/pwm1  N/A  N/A  Auto
           2      2            N/A          hwmon6/pwm2  N/A  N/A  Auto
> Platform: coretemp-isa-0000
  Sensors  Index  Label                       Value
           1      Package id 0 (temp1_input)  66000
           2      Core 0 (temp2_input)        57000
           3      Core 1 (temp3_input)        62000
           4      Core 2 (temp4_input)        64000
           5      Core 3 (temp5_input)        66000
           6      Core 4 (temp6_input)        62000
           7      Core 5 (temp7_input)        62000
           8      Core 6 (temp8_input)        56000
           9      Core 7 (temp9_input)        57000

> Platform: nvme-pci-0e200
  Sensors  Index  Label                    Value
           1      Composite (temp1_input)  50850
           2      Sensor 1 (temp2_input)   50850
           3      Sensor 2 (temp3_input)   50850

> Platform: iwlwifi_1-virtual-0
  Sensors  Index  Label                       Value
           1      hwmon9/temp1 (temp1_input)  47000

> Platform: asus-isa-000a
  Fans     Index  PWM Channel  RPM Channel  Label        RPM   PWM  Mode    
           1      1            1            cpu_fan      2800  N/A  Auto    
           2      2            2            gpu_fan      2800  N/A  Disabled
           3      1            N/A          hwmon5/pwm1  N/A   N/A  Auto    
           4      2            N/A          hwmon5/pwm2  N/A   N/A  Disabled
> Platform: nvme-pci-0e100
  Sensors  Index  Label                    Value
           1      Composite (temp1_input)  46850
           2      Sensor 1 (temp2_input)   46850
           3      Sensor 2 (temp3_input)   48850

> Platform: acpitz-acpi-0
  Sensors  Index  Label                       Value
           1      hwmon1/temp1 (temp1_input)  58000

=========== nvidia: ===========

> Device: nvidia-10DE249D-0100
    Name: NVIDIA GeForce RTX 3070 Laptop GPU
  Sensors  Index  Label  Value
           1      GPU    55000
```