### PR TITLE
Allow compiling without go-nvml support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,6 +63,10 @@ jobs:
           
           make build GOOS="${GOOS}" OARCH="${GOARCH}" GOFLAGS="${GOFLAGS}" OUTPUT_BIN="${OUTPUT_BIN}"
           ./dist/fan2go-linux-amd64 version
+          
+          # same for the version without nvml, to make sure it still compiles
+          make build-no-nvml GOOS="${GOOS}" OARCH="${GOARCH}" GOFLAGS="${GOFLAGS}" OUTPUT_BIN="${OUTPUT_BIN}-no-nvml"
+          ./dist/fan2go-linux-amd64-no-nvml version
 
       # due to the required system dependency on libsensors-dev, and the fact that github doesn't provide arm64 runners,
       # arm64 builds are not possible atm :(

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,6 +68,7 @@ jobs:
           make build-no-nvml GOOS="${GOOS}" OARCH="${GOARCH}" GOFLAGS="${GOFLAGS}" OUTPUT_BIN="${OUTPUT_BIN}-no-nvml"
           ./dist/fan2go-linux-amd64-no-nvml version
 
+
       # due to the required system dependency on libsensors-dev, and the fact that github doesn't provide arm64 runners,
       # arm64 builds are not possible atm :(
       #      - name: Generate build files (arm64)
@@ -76,6 +77,16 @@ jobs:
       #          wget -P "${gcc_cross_path}" https://musl.cc/aarch64-linux-musl-cross.tgz
       #          tar -xvf "${gcc_cross_path}/aarch64-linux-musl-cross.tgz" -C "${gcc_cross_path}"
       #          make build CGO_ENABLED=1 CC="${gcc_cross_path}/aarch64-linux-musl-cross/bin/aarch64-linux-musl-gcc" GOOS="linux" GOARCH="arm64" GOFLAGS="-buildmode=exe" filename="$GOOS-$GOARCH" NAME="fan2go-$filename" OUTPUT_BIN="dist/${NAME}"
+
+      - name: Nvml Check
+        run: |
+          set -x
+          # make sure the no-nvml build *really* doesn't use nvml
+          # ("nvml" is printed by objdump at least once because of the filename,
+          #  but if nvml is linked, it has hundreds of occurences)
+          test `objdump -T ./dist/fan2go-linux-amd64-no-nvml | grep -c nvml` -lt 3
+          # .. and that the regular build *does* have symbols with "nvml" in it
+          test `objdump -T ./dist/fan2go-linux-amd64 | grep -c nvml` -ge 3
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,17 @@ build:  ## Builds the CLI
 	-X ${PACKAGE}/cmd/global.Date=${DATE}" \
 	-a -tags netgo -o "${OUTPUT_BIN}" main.go
 
+build-no-nvml: ## Builds the CLI without nvml (nvidia GPU) support
+	@go build ${GO_FLAGS} \
+	-ldflags "-w -s \
+	-X ${NAME}/cmd/global.Version=${VERSION} \
+	-X ${PACKAGE}/cmd/global.Version=${VERSION} \
+	-X ${NAME}/cmd/global.Commit=${GIT_REV} \
+	-X ${PACKAGE}/cmd/global.Commit=${GIT_REV} \
+	-X ${NAME}/cmd/global.Date=${DATE} \
+	-X ${PACKAGE}/cmd/global.Date=${DATE}" \
+	-a -tags netgo,disable_nvml -o "${OUTPUT_BIN}" main.go
+
 run: build
 	./${OUTPUT_BIN}
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DATE       ?= $(shell date -u -d @${SOURCE_DATE_EPOCH} +"%Y-%m-%dT%H:%M:%SZ")
 VERSION    ?= 0.10.0
 
 test:   ## Run all tests
-	@go clean --testcache && go test -v ./...
+	@go clean --testcache && go test -tags disable_nvml -v ./...
 
 build:  ## Builds the CLI
 	@go build ${GO_FLAGS} \

--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -191,7 +191,7 @@ var detectCmd = &cobra.Command{
 					}
 				}
 				row := []string{
-					"", strconv.Itoa(fan.Index), fan.Label, pwmText, rpmText, fmt.Sprintf("%v", controlModeText),
+					"", strconv.Itoa(fan.GetIndex()), fan.GetLabel(), pwmText, rpmText, fmt.Sprintf("%v", controlModeText),
 				}
 				fanRows = append(fanRows, row)
 			}
@@ -209,7 +209,7 @@ var detectCmd = &cobra.Command{
 					valueText = strconv.Itoa(int(value))
 				}
 
-				row := []string{"", "1", sensor.Label, valueText}
+				row := []string{"", "1", sensor.GetLabel(), valueText}
 				sensorRows = append(sensorRows, row)
 			}
 			var sensorHeaders = []string{"Sensors", "Index", "Label", "Value"}

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/looplab/tarjan"
+	"github.com/markusressel/fan2go/internal/nvidia_base"
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/markusressel/fan2go/internal/util"
 	"golang.org/x/exp/slices"
@@ -74,7 +75,11 @@ func validateSensors(config *Configuration) error {
 			subConfigs++
 		}
 		if sensorConfig.Nvidia != nil {
-			subConfigs++
+			if nvidia_base.IsNvmlSupported {
+				subConfigs++
+			} else {
+				return fmt.Errorf("sensor %s: This version of fan2go was built without NVIDIA (nvml) support", sensorConfig.ID)
+			}
 		}
 		if subConfigs > 1 {
 			return fmt.Errorf("sensor %s: only one sensor type can be used per sensor definition block", sensorConfig.ID)
@@ -253,7 +258,11 @@ func validateFans(config *Configuration) error {
 			subConfigs++
 		}
 		if fanConfig.Nvidia != nil {
-			subConfigs++
+			if nvidia_base.IsNvmlSupported {
+				subConfigs++
+			} else {
+				return fmt.Errorf("fan %s: This version of fan2go was built without NVIDIA (nvml) support", fanConfig.ID)
+			}
 		}
 
 		if subConfigs > 1 {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -584,7 +584,7 @@ func (f *DefaultFanController) ensureNoThirdPartyIsMessingWithUs() {
 
 	if !f.fan.Supports(fans.FeaturePwmSensor) {
 		// we cannot read the PWM value, so we also cannot check if third party changed the PWM value
-		ui.Warning("Fan %s does not support PWM sensor reading, cannot check for third party changes to the PWM value", f.fan.GetId())
+		ui.Debug("Fan %s does not support PWM sensor reading, cannot check for third party changes to the PWM value", f.fan.GetId())
 		return
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -277,9 +277,8 @@ func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, err
 	ui.Info("Loading fan curve data for fan '%s'...", fan.GetId())
 	fanRpmData, err := f.persistence.LoadFanRpmData(fan)
 	if err != nil {
-		switch fan.(type) {
-		case *fans.HwMonFan:
-		case *fans.NvidiaFan:
+		config := fan.GetConfig()
+		if config.HwMon != nil || config.Nvidia != nil {
 			ui.Warning("Fan '%s' has not yet been analyzed, starting initialization sequence...", fan.GetId())
 			err = f.RunInitializationSequence()
 			if err != nil {
@@ -291,7 +290,7 @@ func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, err
 				f.restoreControlMode()
 				return nil, err
 			}
-		default:
+		} else { // file/cmd fan
 			if fan.GetFanRpmCurveData() != nil {
 				err = f.persistence.SaveFanRpmData(fan)
 			}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -3,7 +3,6 @@ package controller
 import (
 	"context"
 	"errors"
-	"fmt"
 	"github.com/markusressel/fan2go/internal/control_loop"
 	"golang.org/x/exp/maps"
 	"math"
@@ -694,30 +693,9 @@ func (f *DefaultFanController) computePwmMap() (err error) {
 
 	var configOverride *map[int]int
 
-	switch f := f.fan.(type) {
-	case *fans.HwMonFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
-		}
-	case *fans.CmdFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
-		}
-	case *fans.FileFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
-		}
-	case *fans.NvidiaFan:
-		c := f.Config.PwmMap
-		if c != nil {
-			configOverride = c
-		}
-	default:
-		// if type is other than above
-		fmt.Println("Type is unknown!")
+	c := f.fan.GetConfig().PwmMap
+	if c != nil {
+		configOverride = c
 	}
 
 	if configOverride != nil {

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -77,6 +77,14 @@ func (fan MockFan) GetStartPwm() int {
 	return 0
 }
 
+func (fan *MockFan) GetLabel() string {
+	return "Mock Fan " + fan.ID
+}
+
+func (fan *MockFan) GetIndex() int {
+	return 1
+}
+
 func (fan *MockFan) SetStartPwm(pwm int, force bool) {
 	panic("not supported")
 }
@@ -858,6 +866,14 @@ func (fan *MockFanWithOffsetPwm) SetControlMode(value fans.ControlMode) (err err
 
 func (fan MockFanWithOffsetPwm) GetId() string {
 	return fan.ID
+}
+
+func (fan *MockFanWithOffsetPwm) GetLabel() string {
+	return "Mock Fan " + fan.ID
+}
+
+func (fan *MockFanWithOffsetPwm) GetIndex() int {
+	return 1
 }
 
 func (fan MockFanWithOffsetPwm) GetName() string {

--- a/internal/fans/cmd.go
+++ b/internal/fans/cmd.go
@@ -22,6 +22,14 @@ func (fan *CmdFan) GetId() string {
 	return fan.Config.ID
 }
 
+func (fan *CmdFan) GetLabel() string {
+	return "CMD Fan " + fan.Config.ID
+}
+
+func (fan *CmdFan) GetIndex() int {
+	return 1
+}
+
 func (fan *CmdFan) GetStartPwm() int {
 	return 1
 }

--- a/internal/fans/common.go
+++ b/internal/fans/common.go
@@ -86,6 +86,9 @@ type Fan interface {
 
 	GetConfig() configuration.FanConfig
 
+	GetLabel() string
+	GetIndex() int
+
 	Supports(feature FeatureFlag) bool
 }
 
@@ -102,19 +105,7 @@ func NewFan(config configuration.FanConfig) (Fan, error) {
 	}
 
 	if config.Nvidia != nil {
-		ret := &NvidiaFan{
-			Label:    config.ID,
-			Index:    config.Nvidia.Index,
-			MinPwm:   config.MinPwm,
-			StartPwm: config.StartPwm,
-			MaxPwm:   config.MaxPwm,
-			Config:   config,
-		}
-		err := ret.Init()
-		if err != nil {
-			return nil, err
-		}
-		return ret, nil
+		return CreateNvidiaFan(config)
 	}
 
 	if config.File != nil {

--- a/internal/fans/file.go
+++ b/internal/fans/file.go
@@ -21,6 +21,14 @@ func (fan *FileFan) GetId() string {
 	return fan.Config.ID
 }
 
+func (fan *FileFan) GetLabel() string {
+	return "File Fan " + fan.Config.ID
+}
+
+func (fan *FileFan) GetIndex() int {
+	return 1
+}
+
 func (fan *FileFan) GetStartPwm() int {
 	return 1
 }

--- a/internal/fans/hwmon.go
+++ b/internal/fans/hwmon.go
@@ -31,6 +31,14 @@ func (fan *HwMonFan) GetId() string {
 	return fan.Config.ID
 }
 
+func (fan *HwMonFan) GetLabel() string {
+	return fan.Label
+}
+
+func (fan *HwMonFan) GetIndex() int {
+	return fan.Index
+}
+
 func (fan *HwMonFan) GetMinPwm() int {
 	// if the fan is never supposed to stop,
 	// use the lowest pwm value where the fan is still spinning

--- a/internal/fans/nvidia.go
+++ b/internal/fans/nvidia.go
@@ -1,3 +1,5 @@
+//go:build !disable_nvml
+
 package fans
 
 import (
@@ -30,6 +32,22 @@ type NvidiaFan struct {
 
 	device    nvml.Device
 	rawDevice nvidia_base.RawNvmlDevice
+}
+
+func CreateNvidiaFan(config configuration.FanConfig) (Fan, error) {
+	ret := &NvidiaFan{
+		Label:    config.ID,
+		Index:    config.Nvidia.Index,
+		MinPwm:   config.MinPwm,
+		StartPwm: config.StartPwm,
+		MaxPwm:   config.MaxPwm,
+		Config:   config,
+	}
+	err := ret.Init()
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
 }
 
 // helper function to turn a nvml error/return code into a go error
@@ -78,6 +96,14 @@ func (fan *NvidiaFan) Init() error {
 
 func (fan *NvidiaFan) GetId() string {
 	return fan.Config.ID
+}
+
+func (fan *NvidiaFan) GetLabel() string {
+	return fan.Label
+}
+
+func (fan *NvidiaFan) GetIndex() int {
+	return fan.Index
 }
 
 func (fan *NvidiaFan) GetMinPwm() int {

--- a/internal/fans/nvidia_stub.go
+++ b/internal/fans/nvidia_stub.go
@@ -1,0 +1,13 @@
+//go:build disable_nvml
+
+package fans
+
+import (
+	"errors"
+
+	"github.com/markusressel/fan2go/internal/configuration"
+)
+
+func CreateNvidiaFan(config configuration.FanConfig) (Fan, error) {
+	return nil, errors.New("This version of fan2go was built without NVIDIA (nvml) support")
+}

--- a/internal/nvidia/nvidia.go
+++ b/internal/nvidia/nvidia.go
@@ -1,3 +1,5 @@
+//go:build !disable_nvml
+
 package nvidia
 
 import (
@@ -10,16 +12,6 @@ import (
 	"github.com/markusressel/fan2go/internal/sensors"
 	"github.com/markusressel/fan2go/internal/ui"
 )
-
-type NvidiaController struct {
-	Identifier string // e.g. "nvidia-10de2489-0400"
-	Name       string // e.g. "NVIDIA GeForce RTX 3060 Ti"
-
-	Fans []fans.NvidiaFan
-	// at least currently nvml only supports one temperature sensor
-	// (pointer in case no sensor was found at all)
-	Sensors []*sensors.NvidiaSensor
-}
 
 func GetDevices() []*NvidiaController {
 	ret := nvml.Init()
@@ -52,7 +44,7 @@ func GetDevices() []*NvidiaController {
 			name = "N/A"
 		}
 
-		var fanSlice = []fans.NvidiaFan{}
+		var fanSlice = []fans.Fan{}
 		numFans, ret := device.GetNumFans()
 		if ret == nvml.SUCCESS && numFans > 0 {
 			for fanIdx := 0; fanIdx < numFans; fanIdx++ {
@@ -60,7 +52,7 @@ func GetDevices() []*NvidiaController {
 				min := 0
 				label := fmt.Sprintf("Fan %d", fanIdx+1)
 
-				fan := fans.NvidiaFan{
+				fan := &fans.NvidiaFan{
 					Config: configuration.FanConfig{
 						ID:     "N/A",
 						MinPwm: &min,
@@ -82,7 +74,7 @@ func GetDevices() []*NvidiaController {
 			}
 		}
 		_, ret = device.GetTemperature(nvml.TEMPERATURE_GPU)
-		var sensorSlice = []*sensors.NvidiaSensor{}
+		var sensorSlice = []sensors.Sensor{}
 		if ret == nvml.SUCCESS {
 			sensor := &sensors.NvidiaSensor{
 				Config: configuration.SensorConfig{

--- a/internal/nvidia/nvidia_common.go
+++ b/internal/nvidia/nvidia_common.go
@@ -1,0 +1,14 @@
+package nvidia
+
+import (
+	"github.com/markusressel/fan2go/internal/fans"
+	"github.com/markusressel/fan2go/internal/sensors"
+)
+
+type NvidiaController struct {
+	Identifier string // e.g. "nvidia-10de2489-0400"
+	Name       string // e.g. "NVIDIA GeForce RTX 3060 Ti"
+
+	Fans    []fans.Fan
+	Sensors []sensors.Sensor
+}

--- a/internal/nvidia/nvidia_stub.go
+++ b/internal/nvidia/nvidia_stub.go
@@ -1,0 +1,8 @@
+//go:build disable_nvml
+
+package nvidia
+
+func GetDevices() []*NvidiaController {
+	// fan2go was built without nvml support => return no devices
+	return nil
+}

--- a/internal/nvidia_base/nvidia_base.go
+++ b/internal/nvidia_base/nvidia_base.go
@@ -1,3 +1,5 @@
+//go:build !disable_nvml
+
 package nvidia_base
 
 // I'd prefer this to just be in nvidia/nvidia.go, but it can't, because that causes

--- a/internal/nvidia_base/nvidia_base.go
+++ b/internal/nvidia_base/nvidia_base.go
@@ -97,6 +97,8 @@ import (
 	"github.com/markusressel/fan2go/internal/ui"
 )
 
+const IsNvmlSupported = true
+
 type RawNvmlDevice unsafe.Pointer
 
 type NvidiaDevice struct {

--- a/internal/nvidia_base/nvidia_base_stub.go
+++ b/internal/nvidia_base/nvidia_base_stub.go
@@ -1,0 +1,8 @@
+//go:build disable_nvml
+
+package nvidia_base
+
+// to be called at the end of main() - otherwise probably don't use this
+func CleanupAtExit() {
+	// do nothing if fan2go was compiled without nvml support
+}

--- a/internal/nvidia_base/nvidia_base_stub.go
+++ b/internal/nvidia_base/nvidia_base_stub.go
@@ -2,6 +2,8 @@
 
 package nvidia_base
 
+const IsNvmlSupported = false
+
 // to be called at the end of main() - otherwise probably don't use this
 func CleanupAtExit() {
 	// do nothing if fan2go was compiled without nvml support

--- a/internal/sensors/cmd.go
+++ b/internal/sensors/cmd.go
@@ -22,6 +22,10 @@ func (sensor *CmdSensor) GetId() string {
 	return sensor.Config.ID
 }
 
+func (sensor *CmdSensor) GetLabel() string {
+	return "CMD Sensor " + sensor.Config.ID
+}
+
 func (sensor *CmdSensor) GetConfig() configuration.SensorConfig {
 	return sensor.Config
 }

--- a/internal/sensors/common.go
+++ b/internal/sensors/common.go
@@ -16,6 +16,8 @@ var (
 type Sensor interface {
 	GetId() string
 
+	GetLabel() string
+
 	GetConfig() configuration.SensorConfig
 
 	// GetValue returns the current value of this sensor
@@ -38,19 +40,7 @@ func NewSensor(config configuration.SensorConfig) (Sensor, error) {
 	}
 
 	if config.Nvidia != nil {
-		ret := &NvidiaSensor{
-			Index:  config.Nvidia.Index,
-			Config: config,
-
-			mu: sync.Mutex{},
-		}
-		err := ret.Init()
-		// if the nvidia device can't be found or its temperature sensor can't be read,
-		// return error instead of an unusable sensor
-		if err != nil {
-			return nil, err
-		}
-		return ret, nil
+		return CreateNvidiaSensor(config)
 	}
 
 	if config.File != nil {

--- a/internal/sensors/file.go
+++ b/internal/sensors/file.go
@@ -21,6 +21,10 @@ func (sensor *FileSensor) GetId() string {
 	return sensor.Config.ID
 }
 
+func (sensor *FileSensor) GetLabel() string {
+	return "File Sensor " + sensor.Config.ID
+}
+
 func (sensor *FileSensor) GetConfig() configuration.SensorConfig {
 	return sensor.Config
 }

--- a/internal/sensors/hwmon.go
+++ b/internal/sensors/hwmon.go
@@ -22,6 +22,10 @@ func (sensor *HwmonSensor) GetId() string {
 	return sensor.Config.ID
 }
 
+func (sensor *HwmonSensor) GetLabel() string {
+	return sensor.Label
+}
+
 func (sensor *HwmonSensor) GetConfig() configuration.SensorConfig {
 	return sensor.Config
 }

--- a/internal/sensors/nvidia.go
+++ b/internal/sensors/nvidia.go
@@ -1,3 +1,5 @@
+//go:build !disable_nvml
+
 package sensors
 
 import (
@@ -25,6 +27,22 @@ type NvidiaSensor struct {
 	mu sync.Mutex
 }
 
+func CreateNvidiaSensor(config configuration.SensorConfig) (Sensor, error) {
+	ret := &NvidiaSensor{
+		Index:  config.Nvidia.Index,
+		Config: config,
+
+		mu: sync.Mutex{},
+	}
+	err := ret.Init()
+	// if the nvidia device can't be found or its temperature sensor can't be read,
+	// return error instead of an unusable sensor
+	if err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
 func (sensor *NvidiaSensor) Init() error {
 	sensor.device, _ = nvidia_base.GetDevice(sensor.Config.Nvidia.Device)
 	if sensor.device == nil {
@@ -44,6 +62,10 @@ func (sensor *NvidiaSensor) Init() error {
 
 func (sensor *NvidiaSensor) GetId() string {
 	return sensor.Config.ID
+}
+
+func (sensor *NvidiaSensor) GetLabel() string {
+	return sensor.Label
 }
 
 func (sensor *NvidiaSensor) GetConfig() configuration.SensorConfig {

--- a/internal/sensors/nvidia_stub.go
+++ b/internal/sensors/nvidia_stub.go
@@ -1,0 +1,13 @@
+//go:build disable_nvml
+
+package sensors
+
+import (
+	"errors"
+
+	"github.com/markusressel/fan2go/internal/configuration"
+)
+
+func CreateNvidiaSensor(config configuration.SensorConfig) (Sensor, error) {
+	return nil, errors.New("This version of fan2go was built without NVIDIA (nvml) support")
+}


### PR DESCRIPTION
@leahneukirchen reported that go-nvml can't be built on musl-based distros, see https://github.com/markusressel/fan2go/pull/373#issuecomment-2954120240

With these changes fan2go can be built without nvml-dependency (`make build-no-nvml`)