### PR TITLE
Enforce lazy binding so go-nvml works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ test:   ## Run all tests
 build:  ## Builds the CLI
 	@go build ${GO_FLAGS} \
 	-ldflags "-w -s \
+	-extldflags=-Wl,-z,lazy \
 	-X ${NAME}/cmd/global.Version=${VERSION} \
 	-X ${PACKAGE}/cmd/global.Version=${VERSION} \
 	-X ${NAME}/cmd/global.Commit=${GIT_REV} \


### PR DESCRIPTION
Some distros seem to default to non-lazy binding ("bind now"), which means that all imported symbols (functions) are resolved when the appliation is started, instead of when they're first called. That breaks go-nvml which loads its wrapped C library (libnvidia-ml.so) with dlopen() but does *not* use dlsym() to load the functions, but instead relies on them just being there, like it would be the case when linking a lib dynamically (instead of loading it dynamically).

Explicitly telling `go build` that lazy binding should be used seems to make it work even on those distros.
Fixes #400 and hopefully #395 as well.