### PR TITLE
feat: expand pwmMap configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,19 +296,38 @@ fans:
     # an increased rotational speed compared to lower values.
     # Note: you can also use this to limit the max speed of a fan.
     maxPwm: 255
-    # (Optional) Override for the PWM map used by fan2go for
-    # mapping the expected [0..255] value range to values actually supported by this fan.
-    # This can be used to compensate for fans with a very limited set of supported values
-    # (f.ex. off, low, high). If not set manually, fan2go will try to compute this mapping
-    # automatically during fan initialization. This process is not perfect though and may
-    # result in suboptimal fan control.
-    # Note: The values of the mapping must be strictly monotonically increasing. The Key-Set must 
-    # be in [0..255] but may omit values. If keys are missing, fan2go will select a key that most 
-    # closely matches the required target value (computed by the referenced curve) during operation.
-    pwmMap:
-      0: 0
-      64: 128
-      192: 255
+    # (Optional) Configure how fan2go maps the internal [0..255] PWM range to
+    # hardware-specific PWM values. If omitted, fan2go auto-detects the mapping
+    # during fan initialization.
+    #
+    # Modes:
+    #
+    # autodetect (default): auto-detect the PWM map during fan initialization.
+    pwmMap: autodetect
+    #
+    # identity: assume a 1:1 mapping (0→0, 1→1, ..., 255→255).
+    # Use this if your fan supports the full PWM range and you want to skip
+    # the initialization measurement.
+    # pwmMap: identity
+    #
+    # linear: linearly interpolate between user-specified control points.
+    # Useful when you know the endpoints (or intermediate points) but want
+    # smooth values in between.
+    # Note: values must be strictly monotonically increasing.
+    # pwmMap:
+    #   linear:
+    #     0: 0
+    #     255: 255
+    #
+    # values: step-interpolate user-specified control points.
+    # Use for fans that only support a limited set of discrete PWM values
+    # (e.g. off / low / medium / high).
+    # Note: values must be strictly monotonically increasing.
+    # pwmMap:
+    #   values:
+    #     0: 0
+    #     64: 128
+    #     192: 255
     # By default (useUnscaledCurveValues: false) speed values from the curve are scaled
     # from 1..255 (or 1%..100%) to MinPwm..MaxPwm  and speed values < 1(%) are set to 0,
     # before they're mapped with pwmMap (the value looked up in pwmMap is then used to

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -144,6 +144,7 @@ func LoadConfig() {
 		&CurrentConfig,
 		viper.DecodeHook(
 			mapstructure.ComposeDecodeHookFunc(
+				pwmMapPointsHookFunc(),
 				DefaultTrueBoolHookFunc(),
 				mapstructure.StringToTimeDurationHookFunc(),
 				mapstructure.StringToSliceHookFunc(","),
@@ -219,6 +220,19 @@ func applyDeprecations() {
 		ui.Warning("controllerAdjustmentTickRate is deprecated, use fanController.adjustmentTickRate instead")
 		CurrentConfig.FanController.AdjustmentTickRate = CurrentConfig.ControllerAdjustmentTickRate
 	}
+}
+
+// UnmarshalText handles string shorthand forms for PwmMapConfig: "autodetect" and "identity".
+func (c *PwmMapConfig) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "autodetect":
+		*c = PwmMapConfig{Autodetect: &PwmMapAutodetectConfig{}}
+	case "identity":
+		*c = PwmMapConfig{Identity: &PwmMapIdentityConfig{}}
+	default:
+		return fmt.Errorf("unknown pwmMap value %q (expected: autodetect, identity, or a map with linear/values key)", string(text))
+	}
+	return nil
 }
 
 // UnmarshalText is a custom unmarshaler for ControlAlgorithmConfig to handle string enum values

--- a/internal/configuration/custom_types.go
+++ b/internal/configuration/custom_types.go
@@ -1,6 +1,7 @@
 package configuration
 
 import (
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -39,6 +40,131 @@ func (b *DefaultTrueBool) Get() bool {
 		return true
 	}
 	return b.Value
+}
+
+// pwmMapPointsHookFunc returns a mapstructure decode hook that handles:
+//  1. Key-type conversion for PwmMapLinearConfig and PwmMapValuesConfig
+//     (interface{} keys from YAML → int).
+//  2. Legacy bare-map format for PwmMapConfig: a numeric-keyed map with no
+//     "linear"/"values"/"autodetect"/"identity" string keys is treated as the
+//     old "values" format and decoded into PwmMapConfig{Values: &pts}.
+func pwmMapPointsHookFunc() mapstructure.DecodeHookFuncType {
+	linearType := reflect.TypeOf(PwmMapLinearConfig{})
+	valuesType := reflect.TypeOf(PwmMapValuesConfig{})
+	pwmMapType := reflect.TypeOf(PwmMapConfig{})
+
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{},
+	) (interface{}, error) {
+		// 3a — key-type conversion for the named map types
+		if t == linearType || t == valuesType {
+			pts, err := parsePwmIntMap(data)
+			if err != nil {
+				return nil, err
+			}
+			if t == linearType {
+				cfg := PwmMapLinearConfig(pts)
+				return cfg, nil
+			}
+			cfg := PwmMapValuesConfig(pts)
+			return cfg, nil
+		}
+
+		// 3b — legacy bare-map backwards compat for PwmMapConfig
+		if t == pwmMapType {
+			if isBarePwmMap(data) {
+				pts, err := parsePwmIntMap(data)
+				if err != nil {
+					return nil, fmt.Errorf("pwmMap (legacy format): %w", err)
+				}
+				cfg := PwmMapValuesConfig(pts)
+				return PwmMapConfig{Values: &cfg}, nil
+			}
+		}
+
+		return data, nil
+	}
+}
+
+// isBarePwmMap returns true when data is a map whose keys are all numeric
+// (no "linear", "values", "autodetect", or "identity" string keys).
+func isBarePwmMap(data interface{}) bool {
+	modeKeys := map[string]bool{"linear": true, "values": true, "autodetect": true, "identity": true}
+	switch v := data.(type) {
+	case map[string]interface{}:
+		for k := range v {
+			if modeKeys[k] {
+				return false
+			}
+		}
+		return len(v) > 0
+	case map[interface{}]interface{}:
+		for k := range v {
+			if ks, ok := k.(string); ok && modeKeys[ks] {
+				return false
+			}
+		}
+		return len(v) > 0
+	}
+	return false
+}
+
+// parsePwmIntMap converts various map types (from YAML decoding) into map[int]int.
+func parsePwmIntMap(data interface{}) (map[int]int, error) {
+	result := make(map[int]int)
+	switch v := data.(type) {
+	case map[interface{}]interface{}:
+		for k, val := range v {
+			key, err := anyToInt(k)
+			if err != nil {
+				return nil, fmt.Errorf("invalid key %v: %w", k, err)
+			}
+			value, err := anyToInt(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %v: %w", val, err)
+			}
+			result[key] = value
+		}
+	case map[string]interface{}:
+		for k, val := range v {
+			key, err := anyToInt(k)
+			if err != nil {
+				return nil, fmt.Errorf("invalid key %q: %w", k, err)
+			}
+			value, err := anyToInt(val)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %v: %w", val, err)
+			}
+			result[key] = value
+		}
+	case map[int]int:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("unsupported point map type %T", data)
+	}
+	return result, nil
+}
+
+// anyToInt converts numeric and string values to int.
+func anyToInt(v interface{}) (int, error) {
+	switch val := v.(type) {
+	case int:
+		return val, nil
+	case int64:
+		return int(val), nil
+	case float64:
+		return int(val), nil
+	case string:
+		n, err := strconv.Atoi(val)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse %q as int: %w", val, err)
+		}
+		return n, nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int", v)
+	}
 }
 
 // DefaultTrueBoolHookFunc returns a mapstructure decode hook function for DefaultTrueBool.

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -4,6 +4,29 @@ import (
 	"time"
 )
 
+// PwmMapConfig selects how the internal [0..255] PWM range is mapped to hardware PWM values.
+// Exactly one sub-config must be non-nil. If PwmMap is nil in FanConfig, autodetect is assumed.
+type PwmMapConfig struct {
+	Autodetect *PwmMapAutodetectConfig `json:"autodetect,omitempty"`
+	Identity   *PwmMapIdentityConfig   `json:"identity,omitempty"`
+	Linear     *PwmMapLinearConfig     `json:"linear,omitempty"`
+	Values     *PwmMapValuesConfig     `json:"values,omitempty"`
+}
+
+// PwmMapAutodetectConfig selects automatic PWM map detection during fan initialization.
+type PwmMapAutodetectConfig struct{}
+
+// PwmMapIdentityConfig selects a 1:1 mapping (0→0, 1→1, ..., 255→255).
+type PwmMapIdentityConfig struct{}
+
+// PwmMapLinearConfig holds control points for linear interpolation.
+// Keys and values must be in [0..255]; values must be strictly monotonically increasing.
+type PwmMapLinearConfig map[int]int
+
+// PwmMapValuesConfig holds control points for step interpolation.
+// Keys and values must be in [0..255]; values must be strictly monotonically increasing.
+type PwmMapValuesConfig map[int]int
+
 type FanConfig struct {
 	// ID is the unique identifier for the fan.
 	ID        string `json:"id"`
@@ -17,7 +40,7 @@ type FanConfig struct {
 	// PwmMap is used to adapt how the expected [0..255] range is applied to a fan.
 	// Some fans have weird missing sections in their PWM range (e.g. 0, 1, 2, 3, 5, 6, 7, 8, 10, ...),
 	// other fans only support a very limited set of PWM values (e.g. 0, 1, 2, 3).
-	PwmMap *map[int]int `json:"pwmMap,omitempty"`
+	PwmMap *PwmMapConfig `json:"pwmMap,omitempty"`
 	// Curve is the id of the speed curve associated with this fan.
 	Curve string `json:"curve"`
 	// By default speed values from the curve are scaled from 1..255 (or 1%..100%) to MinPwm..MaxPwm


### PR DESCRIPTION
## Summary

- Extends `pwmMap` fan configuration from a bare `map[int]int` to a structured config that supports four explicit modes: `autodetect`, `identity`, `linear`, and `values`.
- Adds input validation for `pwmMap` entries (key range, monotonicity, exactly-one-mode constraint).
- The old bare-map format (`pwmMap: { 0: 0, 64: 128 }`) continues to work as a backwards-compatible alias for `values` mode.

## New `pwmMap` modes

| Mode | Description |
|---|---|
| `autodetect` (default) | Auto-detect the PWM map during fan initialization (existing behaviour when `pwmMap` is omitted) |
| `identity` | Skip measurement entirely and assume a 1:1 mapping (0→0, …, 255→255) |
| `linear` | Linearly interpolate between user-specified control points |
| `values` | Step-interpolate user-specified control points (existing manual override behaviour) |

**YAML examples:**
```yaml
pwmMap: autodetect   # string shorthand
pwmMap: identity     # string shorthand

pwmMap:
  linear:
    0: 0
    255: 255

pwmMap:
  values:
    0: 0
    64: 128
    192: 255
```

## Validation

The following are now validated at startup:
- `pwmMap` must have exactly one mode set
- For `linear` and `values`: at least one control point required
- All keys must be in `[0..255]`
- Values must be strictly monotonically increasing

## Test plan

- [x] Verify `pwmMap: autodetect` behaves the same as omitting `pwmMap`
- [x] Verify `pwmMap: identity` skips the initialization measurement
- [x] Verify `pwmMap: { linear: ... }` produces linearly interpolated mapping
- [x] Verify `pwmMap: { values: ... }` produces step-interpolated mapping (same as old bare-map behaviour)
- [x] Verify old bare-map format `pwmMap: { 0: 0, 64: 128 }` still works
- [x] Verify validation rejects invalid configs (out-of-range keys, non-monotonic values, multiple modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR implements the concept described in this comment: https://github.com/markusressel/fan2go/pull/363#issuecomment-2852014619
