### PR TITLE
Add controlMode configuration for fan control mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,24 @@ fans:
     #     0: 0
     #     128: 128
     #     255: 255
+    # (Optional) Configure the control mode fan2go uses while running and on exit.
+    # Both fields are optional; omitting controlMode entirely preserves existing behavior.
+    #
+    # active: the control mode to set when fan2go takes control of this fan.
+    #   Accepts: "pwm" (default, with "disabled" fallback), "disabled", "auto", or an integer.
+    # onExit: what to do when fan2go exits.
+    #   String shorthand:
+    #     onExit: restore   # restore original control mode (default)
+    #     onExit: none      # leave fan at last speed set by fan2go (useful for hardware controllers
+    #                       # that remember PWM settings — see issue #416)
+    #   Map form (set explicit values on exit):
+    #     onExit:
+    #       controlMode: auto   # set a specific control mode on exit
+    #       speed: 128          # set a fixed PWM speed on exit (0..255)
+    #     # controlMode and speed can be combined or used independently.
+    controlMode:
+      active: pwm
+      onExit: restore
     # By default (useUnscaledCurveValues: false) speed values from the curve are scaled
     # from 1..255 (or 1%..100%) to MinPwm..MaxPwm  and speed values < 1(%) are set to 0,
     # before they're mapped with pwmMap (the value looked up in pwmMap is then used to

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -84,6 +84,19 @@ fans:
     # auto-detects this during fan initialization.
     # Modes: autodetect | identity | linear | values
     setPwmToGetPwmMap: autodetect
+    # (Optional) Configure the control mode fan2go uses while running and on exit.
+    # controlMode:
+    #   # (Optional) The control mode to set when fan2go takes control of this fan.
+    #   # Accepts: "pwm" (default), "disabled", "auto", or an integer (0, 1, 2, ...).
+    #   active: pwm
+    #   # (Optional) What to do when fan2go exits. Default: restore original control mode.
+    #   # String shorthands:
+    #   #   onExit: restore   # restore original control mode (default behavior)
+    #   #   onExit: none      # do nothing — leave fan at last speed set by fan2go
+    #   # Map form (set explicit values on exit):
+    #   onExit:
+    #     controlMode: auto  # set control mode on exit (accepts same values as active)
+    #     speed: 128         # set fixed PWM speed on exit (0..255)
     # (Optional) By default (useUnscaledCurveValues: false) speed values from the curve are scaled
     # from 1..255 (or 1%..100%) to MinPwm..MaxPwm  and speed values < 1(%) are set to 0,
     # before they're mapped with pwmMap (the value looked up in pwmMap is then used to

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -235,6 +235,19 @@ func (c *PwmMapConfig) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// UnmarshalText handles string shorthands for OnExitConfig: "restore" and "none".
+func (c *OnExitConfig) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "restore":
+		*c = OnExitConfig{Restore: &OnExitRestoreConfig{}}
+	case "none":
+		*c = OnExitConfig{None: &OnExitNoneConfig{}}
+	default:
+		return fmt.Errorf("unknown onExit value %q (expected: restore, none, or a map with controlMode/speed keys)", string(text))
+	}
+	return nil
+}
+
 // UnmarshalText handles string shorthand forms for SetPwmToGetPwmMapConfig: "autodetect" and "identity".
 func (c *SetPwmToGetPwmMapConfig) UnmarshalText(text []byte) error {
 	switch string(text) {

--- a/internal/configuration/custom_types.go
+++ b/internal/configuration/custom_types.go
@@ -54,12 +54,23 @@ func pwmMapPointsHookFunc() mapstructure.DecodeHookFuncType {
 	pwmMapType := reflect.TypeOf(PwmMapConfig{})
 	setPwmLinearType := reflect.TypeOf(SetPwmToGetPwmMapLinearConfig{})
 	setPwmValuesType := reflect.TypeOf(SetPwmToGetPwmMapValuesConfig{})
+	controlModeValueType := reflect.TypeOf(ControlModeValue(""))
 
 	return func(
 		f reflect.Type,
 		t reflect.Type,
 		data interface{},
 	) (interface{}, error) {
+		// ControlModeValue: allow integer YAML values (e.g. active: 1) to decode as string
+		if t == controlModeValueType {
+			switch v := data.(type) {
+			case int:
+				return ControlModeValue(strconv.Itoa(v)), nil
+			case string:
+				return ControlModeValue(v), nil
+			}
+		}
+
 		// 3a — key-type conversion for the named map types
 		if t == linearType || t == valuesType {
 			pts, err := parsePwmIntMap(data)

--- a/internal/configuration/custom_types_test.go
+++ b/internal/configuration/custom_types_test.go
@@ -296,3 +296,54 @@ func TestSetPwmToGetPwmMapUnmarshalText_Unknown(t *testing.T) {
 	err := cfg.UnmarshalText([]byte("bogus"))
 	assert.Error(t, err)
 }
+
+func TestOnExitConfigUnmarshalText_Restore(t *testing.T) {
+	var cfg OnExitConfig
+	err := cfg.UnmarshalText([]byte("restore"))
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Restore)
+	assert.Nil(t, cfg.None)
+	assert.Nil(t, cfg.ControlMode)
+	assert.Nil(t, cfg.Speed)
+}
+
+func TestOnExitConfigUnmarshalText_RestoreCaseInsensitive(t *testing.T) {
+	var cfg OnExitConfig
+	err := cfg.UnmarshalText([]byte("RESTORE"))
+	assert.NoError(t, err)
+	assert.NotNil(t, cfg.Restore)
+}
+
+func TestOnExitConfigUnmarshalText_None(t *testing.T) {
+	var cfg OnExitConfig
+	err := cfg.UnmarshalText([]byte("none"))
+	assert.NoError(t, err)
+	assert.Nil(t, cfg.Restore)
+	assert.NotNil(t, cfg.None)
+	assert.Nil(t, cfg.ControlMode)
+	assert.Nil(t, cfg.Speed)
+}
+
+func TestOnExitConfigUnmarshalText_Unknown(t *testing.T) {
+	var cfg OnExitConfig
+	err := cfg.UnmarshalText([]byte("bogus"))
+	assert.Error(t, err)
+}
+
+func TestPwmMapPointsHookFunc_ControlModeValue_Int(t *testing.T) {
+	result, err := runPwmMapPointsHook(t, 1, ControlModeValue(""))
+	assert.NoError(t, err)
+	assert.Equal(t, ControlModeValue("1"), result)
+}
+
+func TestPwmMapPointsHookFunc_ControlModeValue_String(t *testing.T) {
+	result, err := runPwmMapPointsHook(t, "pwm", ControlModeValue(""))
+	assert.NoError(t, err)
+	assert.Equal(t, ControlModeValue("pwm"), result)
+}
+
+func TestPwmMapPointsHookFunc_ControlModeValue_Zero(t *testing.T) {
+	result, err := runPwmMapPointsHook(t, 0, ControlModeValue(""))
+	assert.NoError(t, err)
+	assert.Equal(t, ControlModeValue("0"), result)
+}

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -50,6 +50,38 @@ type SetPwmToGetPwmMapLinearConfig map[int]int
 // Keys and values must be in [0..255]; values must be strictly monotonically increasing.
 type SetPwmToGetPwmMapValuesConfig map[int]int
 
+// ControlModeConfig groups active and exit control mode settings for a fan.
+type ControlModeConfig struct {
+	// Active is the control mode to set when fan2go takes control of the fan.
+	// Accepts "pwm", "disabled", or an integer. Defaults to "pwm" (with "disabled" fallback).
+	Active *ControlModeValue `json:"active,omitempty"`
+	// OnExit configures what fan2go does to the fan when it exits.
+	// If omitted, the original control mode is restored (default behavior).
+	OnExit *OnExitConfig `json:"onExit,omitempty"`
+}
+
+// ControlModeValue represents a control mode as a string name or integer string.
+// Accepts: "pwm" / "manual", "disabled", "auto" / "automatic", or integer ("0", "1", "2", ...).
+type ControlModeValue string
+
+// OnExitConfig configures what fan2go does to the fan on exit.
+// Valid combinations:
+//   - restore (alone): restore original control mode — default
+//   - none (alone): do nothing, leave fan at last fan2go speed
+//   - controlMode and/or speed: set explicit values on exit
+type OnExitConfig struct {
+	Restore     *OnExitRestoreConfig `json:"restore,omitempty"`
+	None        *OnExitNoneConfig    `json:"none,omitempty"`
+	ControlMode *ControlModeValue    `json:"controlMode,omitempty"`
+	Speed       *int                 `json:"speed,omitempty"`
+}
+
+// OnExitRestoreConfig restores the original control mode (default behavior).
+type OnExitRestoreConfig struct{}
+
+// OnExitNoneConfig skips all exit actions, leaving the fan at the last speed set by fan2go.
+type OnExitNoneConfig struct{}
+
 type FanConfig struct {
 	// ID is the unique identifier for the fan.
 	ID        string `json:"id"`
@@ -67,6 +99,8 @@ type FanConfig struct {
 	// SetPwmToGetPwmMap configures how fan2go determines the mapping from a set PWM value to the
 	// value the fan hardware reports back. If omitted, fan2go auto-detects this during initialization.
 	SetPwmToGetPwmMap *SetPwmToGetPwmMapConfig `json:"setPwmToGetPwmMap,omitempty"`
+	// ControlMode configures the control mode fan2go uses while active and on exit.
+	ControlMode *ControlModeConfig `json:"controlMode,omitempty"`
 	// Curve is the id of the speed curve associated with this fan.
 	Curve string `json:"curve"`
 	// By default speed values from the curve are scaled from 1..255 (or 1%..100%) to MinPwm..MaxPwm


### PR DESCRIPTION
## Summary

- Adds a new `controlMode:` config block under each fan entry with two optional fields: `active` and `onExit`
- `active`: sets the control mode when fan2go takes control (`"pwm"` (default), `"disabled"`, `"auto"`, or integer)
- `onExit`: configures exit behavior — `restore` (default), `none` (leave fan at last speed), or explicit `controlMode`/`speed` values
- Refactors `trySetManualPwm()` to honour `controlMode.active` instead of always using PWM mode
- Refactors `restoreControlMode()` to honour `controlMode.onExit` instead of always restoring original mode
- Adds `parseControlModeValue()` helper in `internal/controller/controller.go`
- Adds validation for all `controlMode` options at startup
- Documents new options in `fan2go.yaml` (commented examples) and `README.md`

Fixes #416.

## YAML syntax

Both fields are optional. Omitting `controlMode` entirely preserves the existing behavior.

**Use case 1 — default behavior (no config needed):**
```yaml
# fan2go sets PWM mode on start, restores original mode on exit.
# This is what happens when controlMode is omitted entirely.
```

**Use case 2 — set a specific control mode on startup:**
```yaml
controlMode:
  active: disabled  # set pwm_enable to 0 instead of the usual 1 (PWM mode)
                    # also accepts: pwm, auto, or a raw integer (0, 1, 2, ...)
```

**Use case 3 — do nothing on exit (leave fan at last fan2go speed):**
```yaml
# Useful for hardware controllers that remember PWM settings across a reboot.
controlMode:
  onExit: none
```

**Use case 4 — restore original control mode on exit (explicit, same as default):**
```yaml
controlMode:
  onExit: restore
```

**Use case 5 — hand off to motherboard automatic control on exit:**
```yaml
controlMode:
  onExit:
    controlMode: auto  # set pwm_enable to 2 (automatic) on exit
```

**Use case 6 — set a fixed PWM speed on exit (without changing the control mode):**
```yaml
controlMode:
  onExit:
    speed: 128  # set PWM to 128 on exit, leave control mode unchanged
```

**Use case 7 — set both a control mode and a fixed PWM speed on exit:**
```yaml
controlMode:
  onExit:
    controlMode: auto
    speed: 128
```

## Test plan

- [x] `make build-no-nvml` passes
- [x] `make test` — all tests pass (36 new tests added)
- [x] `TestOnExitConfigUnmarshalText_*` — string shorthand parsing
- [x] `TestPwmMapPointsHookFunc_ControlModeValue_*` — integer decode hook
- [x] `TestValidateControlMode_*` — all valid/invalid combinations validated
- [x] `TestParseControlModeValue_*` — mode name and integer parsing
- [x] `TestTrySetManualPwm_*` — active mode config respected
- [x] `TestRestoreControlMode_*` — all onExit variants (default, none, explicit controlMode, speed, both)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


NOTE: `onExit`-> `controlMode` has been renamed to just `mode`:

**Use case 5 — hand off to motherboard automatic control on exit:**
```yaml
controlMode:
  onExit:
    mode: auto  # set pwm_enable to 2 (automatic) on exit
```

**Use case 6 — set a fixed PWM speed on exit (without changing the control mode):**
```yaml
controlMode:
  onExit:
    speed: 128  # set PWM to 128 on exit, leave control mode unchanged
```

**Use case 7 — set both a control mode and a fixed PWM speed on exit:**
```yaml
controlMode:
  onExit:
    mode: auto
    speed: 128
```