### PR TITLE
Split FeatureControlMode into Read/Write, fix SetControlMode logic bug

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -105,7 +105,7 @@ var detectCmd = &cobra.Command{
 				}
 
 				controlModeText := "N/A"
-				if fan.Supports(fans.FeatureControlMode) {
+				if fan.Supports(fans.FeatureControlModeRead) {
 					controlMode, err := fan.GetControlMode()
 					if err == nil {
 						controlModeText = controlModeToString(controlMode)
@@ -184,7 +184,7 @@ var detectCmd = &cobra.Command{
 				}
 
 				controlModeText := "N/A"
-				if fan.Supports(fans.FeatureControlMode) {
+				if fan.Supports(fans.FeatureControlModeRead) {
 					controlMode, err := fan.GetControlMode()
 					if err == nil {
 						controlModeText = controlModeToString(controlMode)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -185,7 +185,7 @@ func (f *DefaultFanController) storeCurrentFanState() error {
 	f.originalPwmValue = pwm
 
 	// store original pwm_enable value
-	if f.fan.Supports(fans.FeatureControlMode) {
+	if f.fan.Supports(fans.FeatureControlModeRead) {
 		controlMode, err := fan.GetControlMode()
 		if err != nil {
 			ui.Warning("Cannot read pwm_enable value of %s", fan.GetId())
@@ -243,7 +243,7 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 		ui.Warning("Suspicious pwm config of fan '%s': MinPwm (%d) > StartPwm (%d)", fan.GetId(), fan.GetMinPwm(), fan.GetStartPwm())
 	}
 
-	// TODO: check if fan.Supports(fans.FeatureControlMode) - or is it ok if it doesn't and our
+	// TODO: check if fan.Supports(fans.FeatureControlModeWrite) - or is it ok if it doesn't and our
 	//       default assumption is that it will always be in manual mode then?
 	//       (trySetManualPwm() just returns nil in that case)
 	//       Alternatively, should fans that don't support switching the mode but run in manual mode
@@ -583,7 +583,7 @@ func parseControlModeValue(value configuration.ControlModeValue) (fans.ControlMo
 }
 
 func trySetManualPwm(fan fans.Fan) error {
-	if !fan.Supports(fans.FeatureControlMode) {
+	if !fan.Supports(fans.FeatureControlModeWrite) {
 		return nil
 	}
 
@@ -635,7 +635,7 @@ func (f *DefaultFanController) restoreControlMode() {
 		if err := f.fan.SetPwm(pwmToSet); err != nil {
 			ui.Warning("Error setting PWM for fan %s on exit: %v", f.fan.GetId(), err)
 		}
-		if onExit.ControlMode != nil && f.fan.Supports(fans.FeatureControlMode) {
+		if onExit.ControlMode != nil && f.fan.Supports(fans.FeatureControlModeWrite) {
 			controlMode, err := parseControlModeValue(*onExit.ControlMode)
 			if err != nil {
 				ui.Warning("Error parsing controlMode.onExit.controlMode for fan %s: %v", f.fan.GetId(), err)
@@ -650,7 +650,7 @@ func (f *DefaultFanController) restoreControlMode() {
 	if err := f.fan.SetPwm(f.originalPwmValue); err != nil {
 		ui.Warning("Error restoring original PWM value for fan %s: %v", f.fan.GetId(), err)
 	}
-	if f.fan.Supports(fans.FeatureControlMode) && f.originalControlMode != fans.ControlModePWM {
+	if f.fan.Supports(fans.FeatureControlModeWrite) && f.originalControlMode != fans.ControlModePWM {
 		if err := f.fan.SetControlMode(f.originalControlMode); err == nil {
 			return
 		}
@@ -769,7 +769,7 @@ func (f *DefaultFanController) ensureFanModeIsSetToExpectedMode() {
 		return
 	}
 
-	if !f.fan.Supports(fans.FeatureControlMode) {
+	if !f.fan.Supports(fans.FeatureControlModeRead) {
 		ui.Warning("Fan %s does not support control mode reading, disabling 'FanModeChangedByThirdParty' sanity check", f.fan.GetId())
 		fanConfig.SanityCheck.FanModeChangedByThirdParty.Enabled.SetOverride(false)
 		f.fan.SetConfig(fanConfig)

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1832,7 +1832,7 @@ func (f *mockFanForRestore) SetControlMode(mode fans.ControlMode) error {
 }
 
 func (f *mockFanForRestore) Supports(feature fans.FeatureFlag) bool {
-	if feature == fans.FeatureControlMode {
+	if feature == fans.FeatureControlModeWrite || feature == fans.FeatureControlModeRead {
 		return f.supportsControlMode
 	}
 	return true

--- a/internal/fans/cmd.go
+++ b/internal/fans/cmd.go
@@ -164,7 +164,9 @@ func (fan *CmdFan) SetConfig(config configuration.FanConfig) {
 
 func (fan *CmdFan) Supports(feature FeatureFlag) bool {
 	switch feature {
-	case FeatureControlMode:
+	case FeatureControlModeWrite:
+		return false
+	case FeatureControlModeRead:
 		return false
 	case FeaturePwmSensor:
 		return fan.Config.Cmd.GetPwm != nil

--- a/internal/fans/cmd_test.go
+++ b/internal/fans/cmd_test.go
@@ -1,11 +1,12 @@
 package fans
 
 import (
+	"os/exec"
+	"testing"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/stretchr/testify/assert"
-	"os/exec"
-	"testing"
 )
 
 func getEchoPath() string {
@@ -436,7 +437,7 @@ func TestCmdFan_SetPwmEnabled(t *testing.T) {
 	assert.Equal(t, ControlModePWM, result)
 }
 
-func TestCmdFan_Supports_ControlMode(t *testing.T) {
+func TestCmdFan_Supports_ControlModeWrite(t *testing.T) {
 	// GIVEN
 	config := configuration.FanConfig{
 		Cmd: &configuration.CmdFanConfig{},
@@ -444,7 +445,7 @@ func TestCmdFan_Supports_ControlMode(t *testing.T) {
 	fan, _ := NewFan(config)
 
 	// WHEN
-	result := fan.Supports(FeatureControlMode)
+	result := fan.Supports(FeatureControlModeWrite)
 
 	// THEN
 	assert.False(t, result)

--- a/internal/fans/common.go
+++ b/internal/fans/common.go
@@ -18,9 +18,10 @@ const (
 type FeatureFlag int
 
 const (
-	FeaturePwmSensor   FeatureFlag = 0
-	FeatureRpmSensor   FeatureFlag = 1
-	FeatureControlMode FeatureFlag = 2
+	FeaturePwmSensor        FeatureFlag = 0
+	FeatureRpmSensor        FeatureFlag = 1
+	FeatureControlModeWrite FeatureFlag = 2
+	FeatureControlModeRead  FeatureFlag = 3
 )
 
 type ControlMode int

--- a/internal/fans/file.go
+++ b/internal/fans/file.go
@@ -173,7 +173,9 @@ func (fan *FileFan) SetConfig(config configuration.FanConfig) {
 
 func (fan *FileFan) Supports(feature FeatureFlag) bool {
 	switch feature {
-	case FeatureControlMode:
+	case FeatureControlModeWrite:
+		return false
+	case FeatureControlModeRead:
 		return false
 	case FeaturePwmSensor:
 		_, err := util.ReadIntFromFile(fan.Config.File.Path)

--- a/internal/fans/file_test.go
+++ b/internal/fans/file_test.go
@@ -1,11 +1,12 @@
 package fans
 
 import (
+	"os"
+	"testing"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestFileFan_NewFan(t *testing.T) {
@@ -426,7 +427,7 @@ func TestFileFan_SetPwmEnabled(t *testing.T) {
 	assert.Equal(t, ControlModePWM, result)
 }
 
-func TestFileFan_Supports_ControlMode(t *testing.T) {
+func TestFileFan_Supports_ControlModeWrite(t *testing.T) {
 	// GIVEN
 	config := configuration.FanConfig{
 		File: &configuration.FileFanConfig{
@@ -438,7 +439,7 @@ func TestFileFan_Supports_ControlMode(t *testing.T) {
 	fan, _ := NewFan(config)
 
 	// WHEN
-	result := fan.Supports(FeatureControlMode)
+	result := fan.Supports(FeatureControlModeWrite)
 
 	// THEN
 	assert.Equal(t, false, result)

--- a/internal/fans/hwmon_test.go
+++ b/internal/fans/hwmon_test.go
@@ -1,11 +1,12 @@
 package fans
 
 import (
+	"os"
+	"testing"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/util"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestHwMonFan_GetId(t *testing.T) {
@@ -358,7 +359,7 @@ func TestHwMonFan_GetControlMode(t *testing.T) {
 	assert.Equal(t, expected, ControlMode(result))
 }
 
-func TestHwMonFan_Supports_ControlMode(t *testing.T) {
+func TestHwMonFan_Supports_ControlModeWrite(t *testing.T) {
 	// GIVEN
 	pwmEnabledPath := "./file_fan_pwm_enabled"
 	defer func(name string) {
@@ -376,13 +377,13 @@ func TestHwMonFan_Supports_ControlMode(t *testing.T) {
 	}
 
 	// WHEN
-	result := fan.Supports(FeatureControlMode)
+	result := fan.Supports(FeatureControlModeWrite)
 
 	// THEN
 	assert.True(t, result)
 }
 
-func TestHwMonFan_Supports_ControlMode_False(t *testing.T) {
+func TestHwMonFan_Supports_ControlModeWrite_False(t *testing.T) {
 	// GIVEN
 	fan := HwMonFan{
 		Config: configuration.FanConfig{
@@ -393,7 +394,48 @@ func TestHwMonFan_Supports_ControlMode_False(t *testing.T) {
 	}
 
 	// WHEN
-	result := fan.Supports(FeatureControlMode)
+	result := fan.Supports(FeatureControlModeWrite)
+
+	// THEN
+	assert.False(t, result)
+}
+
+func TestHwMonFan_Supports_ControlModeRead(t *testing.T) {
+	// GIVEN
+	pwmEnabledPath := "./file_fan_pwm_enabled_read"
+	defer func(name string) {
+		_ = os.Remove(name)
+	}(pwmEnabledPath)
+	err := util.WriteIntToFile(1, pwmEnabledPath)
+	assert.NoError(t, err)
+
+	fan := HwMonFan{
+		Config: configuration.FanConfig{
+			HwMon: &configuration.HwMonFanConfig{
+				PwmEnablePath: pwmEnabledPath,
+			},
+		},
+	}
+
+	// WHEN
+	result := fan.Supports(FeatureControlModeRead)
+
+	// THEN
+	assert.True(t, result)
+}
+
+func TestHwMonFan_Supports_ControlModeRead_False(t *testing.T) {
+	// GIVEN
+	fan := HwMonFan{
+		Config: configuration.FanConfig{
+			HwMon: &configuration.HwMonFanConfig{
+				PwmEnablePath: "./file_fan_pwm_enabled_missing",
+			},
+		},
+	}
+
+	// WHEN
+	result := fan.Supports(FeatureControlModeRead)
 
 	// THEN
 	assert.False(t, result)

--- a/internal/fans/nvidia.go
+++ b/internal/fans/nvidia.go
@@ -272,7 +272,9 @@ func (fan *NvidiaFan) SetConfig(config configuration.FanConfig) {
 
 func (fan *NvidiaFan) Supports(feature FeatureFlag) bool {
 	switch feature {
-	case FeatureControlMode:
+	case FeatureControlModeWrite:
+		return fan.CanSetControlMode
+	case FeatureControlModeRead:
 		return fan.CanSetControlMode
 	case FeaturePwmSensor:
 		// As of today, Nvidia's driver implementation returns a dynamic PWM value based on the


### PR DESCRIPTION
## Summary

Fixes #229 — Dell XPS 7390 (and other systems using `dell_smm_hwmon`) has a **write-only** `pwm_enable` sysfs file: writes succeed but reads fail with `EACCES`. fan2go previously treated control mode support as a single boolean flag (`FeatureControlMode`), causing the read-back check in `ensureFanModeIsSetToExpectedMode()` to fail every control loop iteration and spam the logs.

### What changed

- **Split `FeatureControlMode` into two flags:**
  - `FeatureControlModeWrite` — the `pwm_enable` file exists and can be written (same `os.Stat` logic as before)
  - `FeatureControlModeRead` — the file can actually be read (probed via `ReadIntFromFile` on first call, result cached on `HwMonFan`)

- **Updated all call sites** to use the semantically correct flag:
  - Read operations (`storeCurrentFanState`, `ensureFanModeIsSetToExpectedMode`, `detect` CLI display) → `FeatureControlModeRead`
  - Write operations (`trySetManualPwm`, `restoreControlMode`) → `FeatureControlModeWrite`

- **Fixed a logic bug in `SetControlMode()`** where the "PWM mode stuck" check was inside the `if err != nil` branch, so it compared against the zero value from the error path instead of a successful read. The check is now correctly placed on the success path.

- **All other fan backends** (`FileFan`, `CmdFan`, `NvidiaFan`) updated to handle both new flags.

## Test plan

- [x] `make build-no-nvml` — compiles cleanly
- [x] `make test` — all tests pass
- [x] `golangci-lint run` — no issues
- [x] Added `TestHwMonFan_Supports_ControlModeRead` and `TestHwMonFan_Supports_ControlModeRead_False` tests
- [x] Renamed existing `ControlMode` tests to `ControlModeWrite` for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)