### PR TITLE
feat: channel-based sensor identification for hwmon sensors

### DIFF
--- a/cmd/detect.go
+++ b/cmd/detect.go
@@ -141,10 +141,10 @@ var detectCmd = &cobra.Command{
 				labelAndFile := fmt.Sprintf("%s (%s)", sensor.Label, file)
 
 				sensorRows = append(sensorRows, []string{
-					"", strconv.Itoa(sensor.Index), labelAndFile, valueText,
+					"", strconv.Itoa(sensor.Channel), labelAndFile, valueText,
 				})
 			}
-			var sensorHeaders = []string{"Sensors", "Index", "Label", "Value"}
+			var sensorHeaders = []string{"Sensors", "Channel", "Label", "Value"}
 
 			sensorTable := table.Table{
 				Headers: sensorHeaders,

--- a/internal/configuration/sensors.go
+++ b/internal/configuration/sensors.go
@@ -14,8 +14,10 @@ type SensorConfig struct {
 type HwMonSensorConfig struct {
 	// Platform is the platform of the sensor as printed by 'fan2go detect'
 	Platform string `json:"platform"`
-	// Index is the index of the sensor as printed by 'fan2go detect'
+	// Index is the enumeration index of the sensor as printed by 'fan2go detect' (deprecated: prefer Channel)
 	Index int `json:"index"`
+	// Channel is the hardware channel number of the sensor (e.g. temp3_input → channel 3)
+	Channel int `json:"channel"`
 	// TempInput is the sysfs path to the temperature input
 	TempInput string
 }

--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -95,8 +95,10 @@ func validateSensors(config *Configuration) error {
 		}
 
 		if sensorConfig.HwMon != nil {
-			if sensorConfig.HwMon.Index <= 0 {
-				return fmt.Errorf("sensor %s: invalid index, must be >= 1", sensorConfig.ID)
+			hasIndex := sensorConfig.HwMon.Index > 0
+			hasChannel := sensorConfig.HwMon.Channel > 0
+			if (hasIndex && hasChannel) || (!hasIndex && !hasChannel) {
+				return fmt.Errorf("sensor %s: must have exactly one of index or channel, must be >= 1", sensorConfig.ID)
 			}
 		}
 	}

--- a/internal/sensors/hwmon.go
+++ b/internal/sensors/hwmon.go
@@ -1,14 +1,16 @@
 package sensors
 
 import (
+	"sync"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/util"
-	"sync"
 )
 
 type HwmonSensor struct {
 	Label     string                     `json:"label"`
 	Index     int                        `json:"index"`
+	Channel   int                        `json:"channel"`
 	Input     string                     `json:"string"`
 	Max       int                        `json:"max"`
 	Min       int                        `json:"min"`


### PR DESCRIPTION
## Summary

Closes #286.

This PR adds support for identifying hwmon temperature sensors by their **hardware channel number** (e.g. `temp3_input` → channel `3`) as an alternative to the enumeration index. This makes sensor configuration more stable and predictable — the channel number is derived directly from the sysfs filename and won't shift if other sensors are added or removed.

- Add a `channel` field to `HwMonSensorConfig` (config) and `HwmonSensor` (runtime struct)
- Config validation now requires exactly one of `index` or `channel` to be set (≥ 1); both or neither is an error
- Extract `UpdateSensorConfigFromHwMonControllers()` that resolves a sensor config against live hwmon data, supporting lookup by either `index` or `channel` (mirrors the existing `UpdateFanConfigFromHwMonControllers`)
- `GetTempSensors()` now maps sensors by channel number rather than enumeration index
- `detect` output now shows a **Channel** column for sensors instead of Index

## Test plan

- [x] `go test -tags disable_nvml -v ./internal/hwmon/...` — all tests pass (includes new `TestUpdateSensorConfigFromHwMonControllers`)
- [x] `make test` — full test suite passes
- [x] `fan2go detect` — temperature sensors appear correctly with Channel column

🤖 Generated with [Claude Code](https://claude.com/claude-code)