### PR TITLE
Add per-fan PWM set delay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ fans:
     # an increased rotational speed compared to lower values.
     # Note: you can also use this to limit the max speed of a fan.
     maxPwm: 255
+    # (Optional) Override the global fanController.pwmSetDelay for this specific fan.
+    # Useful when a fan requires more or less time to respond to PWM changes than the global default.
+    # pwmSetDelay: 10ms
     # (Optional) Configure how fan2go maps the internal [0..255] PWM range to
     # hardware-specific PWM values. If omitted, fan2go auto-detects the mapping
     # during fan initialization.

--- a/fan2go.yaml
+++ b/fan2go.yaml
@@ -97,6 +97,8 @@ fans:
     #   onExit:
     #     controlMode: auto  # set control mode on exit (accepts same values as active)
     #     speed: 128         # set fixed PWM speed on exit (0..255)
+    # (Optional) Override the global fanController.pwmSetDelay for this specific fan.
+    # pwmSetDelay: 10ms
     # (Optional) By default (useUnscaledCurveValues: false) speed values from the curve are scaled
     # from 1..255 (or 1%..100%) to MinPwm..MaxPwm  and speed values < 1(%) are set to 0,
     # before they're mapped with pwmMap (the value looked up in pwmMap is then used to

--- a/internal/configuration/fancontroller.go
+++ b/internal/configuration/fancontroller.go
@@ -4,8 +4,8 @@ import "time"
 
 type FanControllerConfig struct {
 	// Time to wait between a set-pwm and get-pwm call. Used to give hardware time to
-	// respond to the set-pwm command.
-	PwmSetDelay time.Duration `json:"pwmSetDelay"` // TODO: this should probably be per fan
+	// respond to the set-pwm command. Can also be set/overridden on a per-fan basis.
+	PwmSetDelay time.Duration `json:"pwmSetDelay"`
 	// Time interval between each fan speed update cycle.
 	AdjustmentTickRate time.Duration `json:"adjustmentTickRate"`
 }

--- a/internal/configuration/fans.go
+++ b/internal/configuration/fans.go
@@ -110,6 +110,8 @@ type FanConfig struct {
 	// are directly mapped with PwmMap, **without** scaling them first.
 	// Note: If NeverStop is also set to true, values smaller than MinPwm (incl. 0) are replaced with MinPwm
 	UseUnscaledCurveValues bool `json:"useUnscaledCurveValues"`
+	// PwmSetDelay overrides the global fanController.pwmSetDelay for this fan.
+	PwmSetDelay *time.Duration `json:"pwmSetDelay,omitempty"`
 	// ControlAlgorithm defines how the curve target is applied to the fan.
 	ControlAlgorithm *ControlAlgorithmConfig `json:"controlAlgorithm,omitempty"`
 	// SanityCheck defines Configuration options for sanity checks

--- a/internal/configuration/validation_test.go
+++ b/internal/configuration/validation_test.go
@@ -3,6 +3,7 @@ package configuration
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -1021,4 +1022,24 @@ func TestValidateDiskSensor_MissingDevice(t *testing.T) {
 
 	// THEN
 	assert.EqualError(t, err, "sensor disk_temp: disk sensor requires a device path")
+}
+
+func TestFanConfig_PwmSetDelay_Set(t *testing.T) {
+	// GIVEN
+	d := 10 * time.Millisecond
+
+	// WHEN
+	fanConfig := FanConfig{PwmSetDelay: &d}
+
+	// THEN
+	assert.NotNil(t, fanConfig.PwmSetDelay)
+	assert.Equal(t, 10*time.Millisecond, *fanConfig.PwmSetDelay)
+}
+
+func TestFanConfig_PwmSetDelay_Absent(t *testing.T) {
+	// GIVEN / WHEN
+	fanConfig := FanConfig{}
+
+	// THEN
+	assert.Nil(t, fanConfig.PwmSetDelay)
 }

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -487,7 +487,7 @@ func (f *DefaultFanController) RunInitializationSequence() (err error) {
 			return err
 		}
 		expectedPwm := f.getReportedPwmAfterApplyingPwm(actualPwm)
-		time.Sleep(configuration.CurrentConfig.FanController.PwmSetDelay)
+		time.Sleep(f.getPwmSetDelay())
 		actualPwm, err := f.getPwm()
 		if err != nil {
 			ui.Error("Fan %s: Unable to measure current PWM", fan.GetId())
@@ -695,6 +695,15 @@ func (f *DefaultFanController) getLastTarget() (int, error) {
 		}
 	}
 	return lastSetPwm, nil
+}
+
+// getPwmSetDelay returns the effective PWM set delay for this fan, using the per-fan override
+// if configured or falling back to the global fanController.pwmSetDelay.
+func (f *DefaultFanController) getPwmSetDelay() time.Duration {
+	if d := f.fan.GetConfig().PwmSetDelay; d != nil {
+		return *d
+	}
+	return configuration.CurrentConfig.FanController.PwmSetDelay
 }
 
 // ensureNoThirdPartyIsMessingWithUs checks if the PWM value of the fan does not match the last
@@ -1050,7 +1059,7 @@ func (f *DefaultFanController) computeSetPwmToGetPwmMapAutomatically() error {
 			ui.Warning("Error setting PWM value %d on fan %s: %v", i, f.fan.GetId(), err)
 			continue
 		}
-		time.Sleep(configuration.CurrentConfig.FanController.PwmSetDelay)
+		time.Sleep(f.getPwmSetDelay())
 		pwm, err := f.fan.GetPwm()
 		if err != nil {
 			ui.Warning("Error reading PWM value of fan %s: %v", f.fan.GetId(), err)

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -77,6 +77,7 @@ type MockFan struct {
 	PwmMap                                       *configuration.PwmMapConfig
 	SetPwmToGetPwmMap                            *configuration.SetPwmToGetPwmMapConfig
 	ControlModeConfig                            *configuration.ControlModeConfig
+	PwmSetDelay                                  *time.Duration
 	setPwmAlwaysFails                            bool
 }
 
@@ -194,6 +195,7 @@ func (fan MockFan) GetConfig() configuration.FanConfig {
 		PwmMap:                 fan.PwmMap,
 		SetPwmToGetPwmMap:      fan.SetPwmToGetPwmMap,
 		ControlMode:            fan.ControlModeConfig,
+		PwmSetDelay:            fan.PwmSetDelay,
 		UseUnscaledCurveValues: fan.useUnscaledCurveValues,
 		HwMon:                  nil, // Not used in this mock
 		File:                   nil, // Not used in this mock
@@ -2081,4 +2083,48 @@ func TestFanController_ComputeFanSpecificMappings_AllWritesFail(t *testing.T) {
 	for i := 0; i < 256; i++ {
 		assert.Equal(t, i, controller.pwmMapping[i], "at index %d", i)
 	}
+}
+
+func TestGetPwmSetDelay_UsesPerFanOverride(t *testing.T) {
+	// GIVEN
+	perFanDelay := 10 * time.Millisecond
+	fan := &MockFan{
+		ID:          "fan",
+		PWM:         0,
+		RPM:         100,
+		PwmSetDelay: &perFanDelay,
+	}
+	configuration.CurrentConfig.FanController.PwmSetDelay = 5 * time.Millisecond
+
+	controller := DefaultFanController{
+		fan: fan,
+	}
+
+	// WHEN
+	result := controller.getPwmSetDelay()
+
+	// THEN
+	assert.Equal(t, perFanDelay, result)
+}
+
+func TestGetPwmSetDelay_FallsBackToGlobal(t *testing.T) {
+	// GIVEN
+	globalDelay := 5 * time.Millisecond
+	fan := &MockFan{
+		ID:  "fan",
+		PWM: 0,
+		RPM: 100,
+	}
+	// PwmSetDelay is nil (not set on fan config)
+	configuration.CurrentConfig.FanController.PwmSetDelay = globalDelay
+
+	controller := DefaultFanController{
+		fan: fan,
+	}
+
+	// WHEN
+	result := controller.getPwmSetDelay()
+
+	// THEN
+	assert.Equal(t, globalDelay, result)
 }


### PR DESCRIPTION
## Summary

Adds a per-fan `pwmSetDelay` override, resolving #385.

`pwmSetDelay` controls how long the controller waits after writing a PWM value before reading it back, giving the hardware time to respond. Previously this was a single global setting. Different fans can have different response characteristics, so this adds the ability to override the global default on a per-fan basis.

## How it works

### Global default (unchanged)

Set a default delay that applies to all fans:

```yaml
fanController:
  pwmSetDelay: 5ms   # applies to every fan unless overridden
```

### Per-fan override (new)

Add `pwmSetDelay` directly on a fan entry to override the global value for that fan only:

```yaml
fans:
  - id: cpu_fan
    curve: cpu_curve
    # no pwmSetDelay → uses the global fanController.pwmSetDelay (5ms above)

  - id: gpu_fan
    curve: gpu_curve
    pwmSetDelay: 20ms   # overrides the global 5ms for this fan only
```

In the example above `cpu_fan` uses the global `5ms`, while `gpu_fan` uses `20ms`.

## Changes

- `internal/configuration/fans.go` — added `PwmSetDelay *time.Duration` to `FanConfig`
- `internal/controller/controller.go` — added `getPwmSetDelay()` helper that returns the per-fan value when set, otherwise falls back to the global `fanController.pwmSetDelay`; replaced both direct usages of the global field with this helper
- `internal/configuration/fancontroller.go` — removed stale TODO comment
- `fan2go.yaml` — added commented example of per-fan override
- `README.md` — documented the new option in the Advanced Fan Options section
- Tests for config field presence/absence and controller fallback logic