### PR TITLE
Enhance PWM validation to support both strictly and non-strictly mono…

### DIFF
--- a/internal/configuration/validation.go
+++ b/internal/configuration/validation.go
@@ -328,7 +328,7 @@ func validateFans(config *Configuration) error {
 			}
 		}
 
-		validatePwmMapPoints := func(label string, pts map[int]int) error {
+		validatePwmMapPoints := func(label string, pts map[int]int, strict bool) error {
 			if len(pts) == 0 {
 				return fmt.Errorf("fan '%s': %s requires at least one control point", fanConfig.ID, label)
 			}
@@ -337,15 +337,17 @@ func validateFans(config *Configuration) error {
 					return fmt.Errorf("fan '%s': %s key %d is out of range [0..255]", fanConfig.ID, label, k)
 				}
 			}
-			sortedKeys := util.SortedKeys(pts)
-			for i := 1; i < len(sortedKeys); i++ {
-				prevKey := sortedKeys[i-1]
-				currKey := sortedKeys[i]
-				if pts[currKey] <= pts[prevKey] {
-					return fmt.Errorf("fan '%s': %s values must be strictly monotonically increasing (at keys %d and %d: %d <= %d)",
-						fanConfig.ID, label, prevKey, currKey, pts[currKey], pts[prevKey])
-				}
+
+			var err error
+			if strict {
+				err = util.IsStrictlyMonotonicallyIncreasing(pts)
+			} else {
+				err = util.IsMonotonicallyIncreasing(pts)
 			}
+			if err != nil {
+				return fmt.Errorf("fan '%s': %s %w", fanConfig.ID, label, err)
+			}
+
 			return nil
 		}
 
@@ -372,12 +374,12 @@ func validateFans(config *Configuration) error {
 			}
 
 			if fanConfig.PwmMap.Linear != nil {
-				if err := validatePwmMapPoints("pwmMap linear", map[int]int(*fanConfig.PwmMap.Linear)); err != nil {
+				if err := validatePwmMapPoints("pwmMap linear", *fanConfig.PwmMap.Linear, true); err != nil {
 					return err
 				}
 			}
 			if fanConfig.PwmMap.Values != nil {
-				if err := validatePwmMapPoints("pwmMap values", map[int]int(*fanConfig.PwmMap.Values)); err != nil {
+				if err := validatePwmMapPoints("pwmMap values", *fanConfig.PwmMap.Values, true); err != nil {
 					return err
 				}
 			}
@@ -406,12 +408,12 @@ func validateFans(config *Configuration) error {
 			}
 
 			if fanConfig.SetPwmToGetPwmMap.Linear != nil {
-				if err := validatePwmMapPoints("setPwmToGetPwmMap linear", map[int]int(*fanConfig.SetPwmToGetPwmMap.Linear)); err != nil {
+				if err := validatePwmMapPoints("setPwmToGetPwmMap linear", *fanConfig.SetPwmToGetPwmMap.Linear, true); err != nil {
 					return err
 				}
 			}
 			if fanConfig.SetPwmToGetPwmMap.Values != nil {
-				if err := validatePwmMapPoints("setPwmToGetPwmMap values", map[int]int(*fanConfig.SetPwmToGetPwmMap.Values)); err != nil {
+				if err := validatePwmMapPoints("setPwmToGetPwmMap values", *fanConfig.SetPwmToGetPwmMap.Values, false); err != nil {
 					return err
 				}
 			}

--- a/internal/configuration/validation_test.go
+++ b/internal/configuration/validation_test.go
@@ -785,6 +785,21 @@ func TestValidateSetPwmToGetPwmMap_NonMonotonic(t *testing.T) {
 	cfg := minimalFanConfigWithSetPwm(&SetPwmToGetPwmMapConfig{Values: &pts})
 	err := validateConfig(&cfg, "")
 	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "monotonically increasing")
+}
+
+func TestValidateSetPwmToGetPwmMap_ValuesEqualAdjacentPointsAreAllowed(t *testing.T) {
+	pts := SetPwmToGetPwmMapValuesConfig{0: 0, 128: 100, 255: 100}
+	cfg := minimalFanConfigWithSetPwm(&SetPwmToGetPwmMapConfig{Values: &pts})
+	err := validateConfig(&cfg, "")
+	assert.NoError(t, err)
+}
+
+func TestValidateSetPwmToGetPwmMap_LinearEqualAdjacentPointsAreRejected(t *testing.T) {
+	pts := SetPwmToGetPwmMapLinearConfig{0: 100, 255: 100}
+	cfg := minimalFanConfigWithSetPwm(&SetPwmToGetPwmMapConfig{Linear: &pts})
+	err := validateConfig(&cfg, "")
+	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "strictly monotonically increasing")
 }
 

--- a/internal/util/math.go
+++ b/internal/util/math.go
@@ -360,3 +360,32 @@ func MaxValOrElse(values []float64, defaultVal float64) float64 {
 	}
 	return maxVal
 }
+
+// IsMonotonicallyIncreasing validates that map values are monotonically increasing when iterating keys in ascending order.
+func IsMonotonicallyIncreasing(values map[int]int) error {
+	return validateMonotonicallyIncreasing(values, false)
+}
+
+// IsStrictlyMonotonicallyIncreasing validates that map values are strictly monotonically increasing when iterating keys in ascending order.
+func IsStrictlyMonotonicallyIncreasing(values map[int]int) error {
+	return validateMonotonicallyIncreasing(values, true)
+}
+
+func validateMonotonicallyIncreasing(values map[int]int, strict bool) error {
+	sortedKeys := SortedKeys(values)
+	for i := 1; i < len(sortedKeys); i++ {
+		prevKey := sortedKeys[i-1]
+		currKey := sortedKeys[i]
+		prevVal := values[prevKey]
+		currVal := values[currKey]
+
+		if strict && currVal <= prevVal {
+			return fmt.Errorf("values must be strictly monotonically increasing (at keys %d and %d: %d <= %d)", prevKey, currKey, currVal, prevVal)
+		}
+		if !strict && currVal < prevVal {
+			return fmt.Errorf("values must be monotonically increasing (at keys %d and %d: %d < %d)", prevKey, currKey, currVal, prevVal)
+		}
+	}
+
+	return nil
+}

--- a/internal/util/math_test.go
+++ b/internal/util/math_test.go
@@ -273,3 +273,23 @@ func TestMaxValOrElseEmpty(t *testing.T) {
 	// THEN
 	assert.Equal(t, defaultValue, result)
 }
+
+func TestIsMonotonicallyIncreasing_AllowsEqualAdjacentValues(t *testing.T) {
+	err := IsMonotonicallyIncreasing(map[int]int{0: 10, 64: 10, 255: 20})
+	assert.NoError(t, err)
+}
+
+func TestIsMonotonicallyIncreasing_RejectsDecreasingValues(t *testing.T) {
+	err := IsMonotonicallyIncreasing(map[int]int{0: 10, 64: 9, 255: 20})
+	assert.EqualError(t, err, "values must be monotonically increasing (at keys 0 and 64: 9 < 10)")
+}
+
+func TestIsStrictlyMonotonicallyIncreasing_RejectsEqualAdjacentValues(t *testing.T) {
+	err := IsStrictlyMonotonicallyIncreasing(map[int]int{0: 10, 64: 10, 255: 20})
+	assert.EqualError(t, err, "values must be strictly monotonically increasing (at keys 0 and 64: 10 <= 10)")
+}
+
+func TestIsStrictlyMonotonicallyIncreasing_AllowsStrictIncrease(t *testing.T) {
+	err := IsStrictlyMonotonicallyIncreasing(map[int]int{0: 10, 64: 11, 255: 20})
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This pull request refactors and improves the validation logic for fan PWM map configurations, introducing clearer rules for monotonicity and strict monotonicity. It adds utility functions for these checks, updates the validation logic to use them, and enhances test coverage to ensure correct behavior.

**Validation logic improvements:**

* Refactored the `validatePwmMapPoints` function in `internal/configuration/validation.go` to accept a `strict` parameter and use new utility functions for monotonic and strictly monotonic validation. This ensures that linear PWM maps require strictly increasing values, while value-based maps allow equal adjacent values where appropriate. [[1]](diffhunk://#diff-d1ad77577a7eb2bf25d2d5e720cd96d1d17d41eb9725e03cf09dfd9be4c8e2e1L331-R331) [[2]](diffhunk://#diff-d1ad77577a7eb2bf25d2d5e720cd96d1d17d41eb9725e03cf09dfd9be4c8e2e1L340-R350) [[3]](diffhunk://#diff-d1ad77577a7eb2bf25d2d5e720cd96d1d17d41eb9725e03cf09dfd9be4c8e2e1L375-R382) [[4]](diffhunk://#diff-d1ad77577a7eb2bf25d2d5e720cd96d1d17d41eb9725e03cf09dfd9be4c8e2e1L409-R416)

**Utility functions:**

* Added `IsMonotonicallyIncreasing` and `IsStrictlyMonotonicallyIncreasing` functions to `internal/util/math.go`, centralizing the logic for checking monotonicity and strict monotonicity of map values.

**Test coverage:**

* Added and updated tests in `internal/configuration/validation_test.go` and `internal/util/math_test.go` to verify that the new validation rules work as intended, including cases for equal adjacent values and strictly increasing sequences. [[1]](diffhunk://#diff-f228b02e5ad73f68665d5be919fcda91ce2bc821325fda4cdf7f565935a0495aR788-R802) [[2]](diffhunk://#diff-42b02b57af9388d75358e3a55707f412336a9707f68036cb780be52979892388R276-R295)…tonically increasing values