### PR TITLE
hwmon: Allow empty fan curve

### DIFF
--- a/internal/fans/hwmon.go
+++ b/internal/fans/hwmon.go
@@ -123,11 +123,10 @@ func (fan *HwMonFan) GetFanRpmCurveData() *map[int]float64 {
 // AttachFanCurveData attaches fan curve data from persistence to a fan
 // Note: When the given data is incomplete, all values up until the highest
 // value in the given dataset will be interpolated linearly
-// returns os.ErrInvalid if curveData is void of any data
 func (fan *HwMonFan) AttachFanRpmCurveData(curveData *map[int]float64) (err error) {
 	if curveData == nil || len(*curveData) <= 0 {
-		ui.Error("Can't attach empty fan curve data to fan %s", fan.GetId())
-		return os.ErrInvalid
+		fan.FanCurveData = nil
+		return err
 	}
 
 	fan.FanCurveData = curveData


### PR DESCRIPTION
The fan analyzer returns a nil rpmCurve if the rpm sensor is missing. This results in an error in hwmon, which prevents the controlling of fans without a rpm sensor.

Allow an empty fan curve in order to control hwmon fans without rpm sensor. Max/min/start rpm values can be read from the config or default to MIN_PWM_VALUE/MAX_PWM_VALUE.

Fixes https://github.com/markusressel/fan2go/issues/483