### PR TITLE
Reduce startup delay

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -209,7 +209,7 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 
 	ui.Info("Gathering sensor data for %s...", fan.GetId())
 	// wait a bit to gather monitoring data
-	time.Sleep(2*time.Second + configuration.CurrentConfig.TempSensorPollingRate*2)
+	time.Sleep(2*time.Second + configuration.CurrentConfig.TempSensorPollingRate)
 
 	fanPwmData, err := f.runInitializationIfNeeded()
 	if err != nil {

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -289,6 +289,14 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 			time.Sleep(1 * time.Second)
 			tick := time.NewTicker(f.updateRate)
 			defer tick.Stop()
+
+			err = f.UpdateFanSpeed()
+			if err != nil {
+				ui.ErrorAndNotify("Fan Control Error", "Fan %s: %v", fan.GetId(), err)
+				f.restoreControlMode()
+				return nil
+			}
+
 			for {
 				select {
 				case <-controllerCtx.Done():

--- a/internal/monitor.go
+++ b/internal/monitor.go
@@ -2,11 +2,12 @@ package internal
 
 import (
 	"context"
+	"time"
+
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/sensors"
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/markusressel/fan2go/internal/util"
-	"time"
 )
 
 type SensorMonitor interface {
@@ -27,6 +28,12 @@ func NewSensorMonitor(sensor sensors.Sensor, pollingRate time.Duration) SensorMo
 
 func (s sensorMonitor) Run(ctx context.Context) error {
 	tick := time.NewTicker(s.pollingRate)
+
+	err := updateSensor(s.sensor)
+	if err != nil {
+		ui.Warning("Error updating sensor: %v", err)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
When starting, the daemon waits for the tempSensorPollingRate and adjustmentTickRate.

This makes the daemon start instantly.
