### PR TITLE
Fix outdated staircase example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,8 @@ curves:
   - id: staircase_curve
     staircase:
       sensor: cpu_package
-      threshold: 6
+      hysteresis:
+        down: 6
       steps:
         # Sensor value (in degrees Celsius) -> Speed (0-255)
         - 40: 1


### PR DESCRIPTION
Sorry. I forgot to update the example in the readme in #486 (https://github.com/markusressel/fan2go/commit/d8f5e93feb670d8b90120a54e865854d1772b0e4 specificly)