### PR TITLE
Feature/auto reload on file changes

### DIFF
--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -17,10 +17,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-const (
-	FanModeSanityCheckDefaultThrottleDuration = 10 * time.Second
-)
-
 type Configuration struct {
 	DbPath string `json:"dbPath"`
 

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -173,37 +173,46 @@ func LoadConfig() (Configuration, error) {
 
 	// apply default values again to set any nested struct defaults that were
 	// created after the initial parsing pass
-	if err := defaults.Set(&cfg); err != nil {
+	if err = defaults.Set(&cfg); err != nil {
 		return cfg, err
 	}
 
-	applyTransformations(&cfg)
+	if err = applyTransformations(&cfg); err != nil {
+		return cfg, err
+	}
 
-	applyDeprecations(&cfg)
+	if err = applyDeprecations(&cfg); err != nil {
+		return cfg, err
+	}
 
 	return cfg, nil
 }
 
 // apply transformations between different formats available to configure fan curves
-func applyTransformations(cfg *Configuration) {
+func applyTransformations(cfg *Configuration) error {
 	// convert steps in linear curves from strings (with plain numbers or percent values) to floats between 0 and 255
 	for i, curve := range cfg.Curves {
 		if curve.Linear != nil && len(curve.Linear.InSteps) > 0 {
-			transformCurveSteps(&curve.ID, &curve.Linear.Steps, &curve.Linear.InSteps)
+			if err := transformCurveSteps(&curve.ID, &curve.Linear.Steps, &curve.Linear.InSteps); err != nil {
+				return err
+			}
 			cfg.Curves[i] = curve
 		}
 		if curve.Staircase != nil {
 			if len(curve.Staircase.InSteps) > 0 {
-				transformCurveSteps(&curve.ID, &curve.Staircase.Steps, &curve.Staircase.InSteps)
+				if err := transformCurveSteps(&curve.ID, &curve.Staircase.Steps, &curve.Staircase.InSteps); err != nil {
+					return err
+				}
 				cfg.Curves[i] = curve
 			} else {
-				ui.Fatal("Missing steps in curve %s", curve.ID)
+				return fmt.Errorf("Missing steps in curve %s", curve.ID)
 			}
 		}
 	}
+	return nil
 }
 
-func transformCurveSteps(ID *string, Steps *map[int]float64, InSteps *map[int]string) {
+func transformCurveSteps(ID *string, Steps *map[int]float64, InSteps *map[int]string) error {
 	*Steps = make(map[int]float64)
 
 	for temp, origstr := range *InSteps {
@@ -216,36 +225,39 @@ func transformCurveSteps(ID *string, Steps *map[int]float64, InSteps *map[int]st
 		}
 		speed, err := strconv.ParseFloat(str, 64)
 		if err != nil {
-			ui.Fatal("Invalid curve step value '%s' in %s - must be either just a number or a number followed by '%%'", origstr, *ID)
-		} else {
-			if isPercent {
-				if speed < 0 || speed > 100 {
-					ui.Fatal("invalid curve step value '%s' (=> %f) in %s - must be between 0%% and 100%%", origstr, speed, *ID)
-				}
-				// convert 0-100% into [0..255]
-				if speed < 1 {
-					// less than 1% always turns into 0
-					speed = 0
-				} else {
-					// 1% turns into 1, 100% turns into 255
-					// => convert 1..100% to 1..255
-					// => 0..99 to 0..254 and then add 1
-					speed = (speed-1)*(254.0/99.0) + 1
-				}
-			} else if speed < 0 || speed > 255 {
-				ui.Fatal("invalid curve step value '%s' in %s - must be between 0 and 255", origstr, *ID)
-			}
-			(*Steps)[temp] = speed
+			return fmt.Errorf("invalid curve step value '%s' in %s - must be either just a number or a number followed by '%%'", origstr, *ID)
 		}
+
+		if isPercent {
+			if speed < 0 || speed > 100 {
+				return fmt.Errorf("invalid curve step value '%s' (=> %f) in %s - must be between 0%% and 100%%", origstr, speed, *ID)
+			}
+			// convert 0-100% into [0..255]
+			if speed < 1 {
+				// less than 1% always turns into 0
+				speed = 0
+			} else {
+				// 1% turns into 1, 100% turns into 255
+				// => convert 1..100% to 1..255
+				// => 0..99 to 0..254 and then add 1
+				speed = (speed-1)*(254.0/99.0) + 1
+			}
+		} else if speed < 0 || speed > 255 {
+			return fmt.Errorf("invalid curve step value '%s' (=> %f) in %s - must be between 0 and 255", origstr, speed, *ID)
+		}
+		(*Steps)[temp] = speed
 	}
+
+	return nil
 }
 
 // apply deprecations and migrate values
-func applyDeprecations(cfg *Configuration) {
+func applyDeprecations(cfg *Configuration) error {
 	if cfg.ControllerAdjustmentTickRate > 0 {
 		ui.Warning("controllerAdjustmentTickRate is deprecated, use fanController.adjustmentTickRate instead")
 		cfg.FanController.AdjustmentTickRate = cfg.ControllerAdjustmentTickRate
 	}
+	return nil
 }
 
 // UnmarshalText handles string shorthand forms for PwmMapConfig: "autodetect" and "identity".

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -130,19 +130,19 @@ func setDefaultValues() {
 
 // DetectAndReadConfigFile detects the path of the first existing config file
 func DetectAndReadConfigFile() string {
-	err := readInConfig()
+	err := ReadInConfig()
 	if err != nil {
 		ui.FatalWithoutStacktrace("Error reading config file, %s", err)
 	}
 	return GetFilePath()
 }
 
-// readInConfig reads and parses the config file
-func readInConfig() error {
+// ReadInConfig reads and parses the config file
+func ReadInConfig() error {
 	return viper.ReadInConfig()
 }
 
-// GetFilePath this is only populated _after_ readInConfig()
+// GetFilePath this is only populated _after_ ReadInConfig()
 func GetFilePath() string {
 	return viper.ConfigFileUsed()
 }

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -201,7 +201,7 @@ func applyTransformations(cfg *Configuration) error {
 				}
 				cfg.Curves[i] = curve
 			} else {
-				return fmt.Errorf("Missing steps in curve %s", curve.ID)
+				return fmt.Errorf("missing steps in curve %s", curve.ID)
 			}
 		}
 	}

--- a/internal/daemon.go
+++ b/internal/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/markusressel/fan2go/internal/persistence"
 	"github.com/markusressel/fan2go/internal/registry"
 	"github.com/markusressel/fan2go/internal/ui"
+	"github.com/markusressel/fan2go/internal/util"
 	"github.com/oklog/run"
 )
 
@@ -92,6 +93,12 @@ func runFileWatcher(ctx context.Context, configPath string, reloadChan chan<- st
 	}
 	defer watcher.Close()
 
+	// Store the last known hash to compare against
+	lastHash, err := util.HashFile(configPath)
+	if err != nil {
+		ui.Warning("Could not compute initial hash for config file: %v", err)
+	}
+
 	err = watcher.Add(configPath)
 	if err != nil {
 		return err
@@ -105,13 +112,27 @@ func runFileWatcher(ctx context.Context, configPath string, reloadChan chan<- st
 			if !ok {
 				return nil
 			}
-			// Trigger on Write or Rename (some editors rename temp files on save)
+
+			// Trigger on Write
 			if event.Op&fsnotify.Write == fsnotify.Write {
-				ui.Info("Config file modification detected...")
-				select {
-				case reloadChan <- struct{}{}:
-				default:
-					// Ignore if a reload is already in progress
+				newHash, err := util.HashFile(configPath)
+				if err != nil {
+					ui.Warning("Could not compute hash after file change: %v", err)
+					continue
+				}
+
+				// Only notify if the content actually changed
+				if newHash != lastHash {
+					ui.Info("Config file content change detected.")
+					lastHash = newHash
+
+					select {
+					case reloadChan <- struct{}{}:
+					default:
+						ui.Warning("Reload already in progress, ignoring SIGHUP.")
+					}
+				} else {
+					ui.Debug("File write detected, but content is identical. Skipping reload.")
 				}
 			}
 		case err, ok := <-watcher.Errors:
@@ -185,6 +206,10 @@ func runOrchestratorCycle(ctx context.Context, reloadChan <-chan struct{}, reg *
 func reloadConfiguration(pers persistence.Persistence) (*registry.Registry, map[fans.Fan]controller.FanController, error) {
 	ui.Info("Reloading configuration...")
 
+	err := configuration.ReadInConfig()
+	if err != nil {
+		return nil, nil, fmt.Errorf("error reading config file: %w", err)
+	}
 	newConfig, err := configuration.LoadConfig()
 	if err != nil {
 		return nil, nil, fmt.Errorf("parsing failed: %w", err)

--- a/internal/daemon.go
+++ b/internal/daemon.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/controller"
 	"github.com/markusressel/fan2go/internal/fans"
@@ -66,6 +67,12 @@ func RunDaemon() {
 		func(err error) { cancel() },
 	)
 
+	// === ACTOR 3: Config File Watcher ===
+	g.Add(
+		func() error { return runFileWatcher(ctx, configuration.GetFilePath(), reloadChan) },
+		func(err error) { /* handled by context cancellation */ },
+	)
+
 	err = g.Run()
 
 	cancel()
@@ -78,7 +85,43 @@ func RunDaemon() {
 	os.Exit(0)
 }
 
-// --- Extracted Helper Functions ---
+func runFileWatcher(ctx context.Context, configPath string, reloadChan chan<- struct{}) error {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	defer watcher.Close()
+
+	err = watcher.Add(configPath)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case event, ok := <-watcher.Events:
+			if !ok {
+				return nil
+			}
+			// Trigger on Write or Rename (some editors rename temp files on save)
+			if event.Op&fsnotify.Write == fsnotify.Write {
+				ui.Info("Config file modification detected...")
+				select {
+				case reloadChan <- struct{}{}:
+				default:
+					// Ignore if a reload is already in progress
+				}
+			}
+		case err, ok := <-watcher.Errors:
+			if !ok {
+				return nil
+			}
+			ui.Warning("File watcher error: %v", err)
+		}
+	}
+}
 
 func checkProcessOwner() {
 	owner, err := getProcessOwner()

--- a/internal/daemon.go
+++ b/internal/daemon.go
@@ -91,7 +91,12 @@ func runFileWatcher(ctx context.Context, configPath string, reloadChan chan<- st
 	if err != nil {
 		return err
 	}
-	defer watcher.Close()
+	defer func(watcher *fsnotify.Watcher) {
+		err := watcher.Close()
+		if err != nil {
+			ui.Warning("Could not close file watcher: %v", err)
+		}
+	}(watcher)
 
 	// Store the last known hash to compare against
 	lastHash, err := util.HashFile(configPath)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -1,16 +1,20 @@
 package util
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/markusressel/fan2go/internal/ui"
-	"github.com/natefinch/atomic"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/markusressel/fan2go/internal/ui"
+	"github.com/natefinch/atomic"
 )
 
 // CheckFilePermissionsForExecution checks whether the given filePath owner, group and permissions
@@ -122,4 +126,19 @@ func FindFilesMatching(path string, expr *regexp.Regexp) []string {
 	}
 
 	return result
+}
+
+// HashFile computes the SHA-256 hash of the file at configPath
+func HashFile(configPath string) (string, error) {
+	f, err := os.Open(configPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -134,7 +134,12 @@ func HashFile(configPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func(f *os.File) {
+		err := f.Close()
+		if err != nil {
+			ui.Warning("File close error: %v", err)
+		}
+	}(f)
 
 	h := sha256.New()
 	if _, err := io.Copy(h, f); err != nil {


### PR DESCRIPTION
This PR introduces automatic configuration reloading to `fan2go`. The daemon now watches the configuration file for changes and automatically applies them without requiring a manual restart or a `SIGHUP` signal.

Contributes to #424

To prevent unnecessary reloads (e.g., when a file is saved without actual content changes), the system first computes a hash of the file. A reload is only triggered if the hash has changed.

Additionally, this change includes a significant refactoring of the configuration loading logic. Error handling has been improved by propagating
 errors up the call stack instead of calling `ui.Fatal`, making the reload process more robust and preventing the daemon from crashing on a faulty configuration reload.

### Changes:

- **feat(reload):** Added a file watcher to automatically reload the configuration on change.
- **refactor(config):** Improved
 error handling in the configuration module by returning errors instead of using `ui.Fatal`.
- **fix(reload):** Ensure the configuration is re-read from the file before applying it during a reload.
- **chore(cleanup):** Removed unused code.