### PR TITLE
Fix nil pointer dereference on missing rpm curve

### DIFF
--- a/internal/persistence/persistence.go
+++ b/internal/persistence/persistence.go
@@ -85,8 +85,13 @@ func (p persistence) SaveFanRpmData(fan fans.Fan) (err error) {
 
 	// convert the curve data moving window to a map to arrays, so we can persist them
 	fanCurveDataMap := map[int]float64{}
-	for key, value := range *fan.GetFanRpmCurveData() {
-		fanCurveDataMap[key] = value
+
+	if fan.GetFanRpmCurveData() == nil {
+		fanCurveDataMap = nil
+	} else {
+		for key, value := range *fan.GetFanRpmCurveData() {
+			fanCurveDataMap[key] = value
+		}
 	}
 
 	data, err := json.Marshal(fanCurveDataMap)


### PR DESCRIPTION
Might be a little late. After deleting the fan2go.db file and restarting the daemon, it would crash. The only reason it worked flawlessly until now was, because it still had the empty rpm fan curve inside the database. Likely a regression from adding the `FanCurveData = nil` statement in `AttachFanRpmCurveData`, which only occurs if the rpm sensor is missing.

<br><br>

If the fan rpm curve is nil, the daemon crashes when trying to save the fan rpm curve.

Add check if the fan rpm curve is nil. If so, serialize null into the datbabase. If we skip the CreateBucketIfNotExists inside SaveFanRpmData the daemon would fail on LoadFanRpmData (which is executed directly after the save in fan controller)

