### PR TITLE
fix(statistics): honor the configured statistics host

### DIFF
--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -95,8 +95,10 @@ func setDefaultValues() {
 
 	viper.SetDefault("Statistics", StatisticsConfig{
 		Enabled: false,
+		Host:    "",
 		Port:    9000,
 	})
+	viper.SetDefault("Statistics.Host", "")
 	viper.SetDefault("Statistics.Port", 9000)
 
 	viper.SetDefault("Api", ApiConfig{

--- a/internal/configuration/statistics.go
+++ b/internal/configuration/statistics.go
@@ -1,6 +1,7 @@
 package configuration
 
 type StatisticsConfig struct {
-	Enabled bool `json:"enabled"`
-	Port    int  `json:"port,omitempty"`
+	Enabled bool   `json:"enabled"`
+	Host    string `json:"host"`
+	Port    int    `json:"port,omitempty"`
 }

--- a/internal/webservers.go
+++ b/internal/webservers.go
@@ -84,7 +84,7 @@ func startRestServer(reg *registry.Registry) *echo.Echo {
 
 	go func() {
 		apiConfig := configuration.CurrentConfig.Api
-		restAddress := fmt.Sprintf("%s:%d", apiConfig.Host, apiConfig.Port)
+		restAddress := webserverAddress(apiConfig.Host, apiConfig.Port)
 
 		if err := restServer.Start(restAddress); err != nil && err != http.ErrServerClosed {
 			ui.ErrorAndNotify("REST Error", "Cannot start REST Api endpoint (%s)", err.Error())
@@ -100,8 +100,8 @@ func startStatisticsServer() *echo.Echo {
 	echoPrometheus := statistics.CreateStatisticsService()
 
 	go func() {
-		prometheusPort := configuration.CurrentConfig.Statistics.Port
-		prometheusAddress := fmt.Sprintf(":%d", prometheusPort)
+		statisticsConfig := configuration.CurrentConfig.Statistics
+		prometheusAddress := webserverAddress(statisticsConfig.Host, statisticsConfig.Port)
 
 		if err := echoPrometheus.Start(prometheusAddress); err != nil && err != http.ErrServerClosed {
 			ui.ErrorAndNotify("Statistics Error", "Cannot start prometheus metrics endpoint (%s)", err.Error())
@@ -109,4 +109,8 @@ func startStatisticsServer() *echo.Echo {
 	}()
 
 	return echoPrometheus
+}
+
+func webserverAddress(host string, port int) string {
+	return fmt.Sprintf("%s:%d", host, port)
 }

--- a/internal/webservers_test.go
+++ b/internal/webservers_test.go
@@ -1,0 +1,73 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/markusressel/fan2go/internal/configuration"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebserverAddress(t *testing.T) {
+	testCases := []struct {
+		name     string
+		host     string
+		port     int
+		expected string
+	}{
+		{
+			name:     "empty host",
+			host:     "",
+			port:     9000,
+			expected: ":9000",
+		},
+		{
+			name:     "IPv4 host",
+			host:     "127.0.0.1",
+			port:     9000,
+			expected: "127.0.0.1:9000",
+		},
+		{
+			name:     "bracketed IPv6 host with zone",
+			host:     "[fe80::18c2:b5ff:fec0:71b8%vmbr1]",
+			port:     9000,
+			expected: "[fe80::18c2:b5ff:fec0:71b8%vmbr1]:9000",
+		},
+		{
+			name:     "bracketed IPv6 host",
+			host:     "[::1]",
+			port:     9000,
+			expected: "[::1]:9000",
+		},
+		{
+			name:     "REST API host",
+			host:     "127.0.0.1",
+			port:     9001,
+			expected: "127.0.0.1:9001",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.expected, webserverAddress(testCase.host, testCase.port))
+		})
+	}
+}
+
+func TestStatisticsConfigUnmarshalsHost(t *testing.T) {
+	v := viper.New()
+	v.SetConfigType("yaml")
+	require.NoError(t, v.ReadConfig(strings.NewReader(`
+statistics:
+  enabled: true
+  host: "[fe80::18c2:b5ff:fec0:71b8%vmbr1]"
+  port: 9000
+`)))
+
+	var config struct {
+		Statistics configuration.StatisticsConfig
+	}
+	require.NoError(t, v.Unmarshal(&config))
+	require.Equal(t, "[fe80::18c2:b5ff:fec0:71b8%vmbr1]", config.Statistics.Host)
+}


### PR DESCRIPTION
Go's IPv6 handling is fine here and nothing needs implementing for it. The asymmetry in #507 is that `StatisticsConfig` has no `Host` field at all, so `statistics.host` is discarded when the config is unmarshalled, and `startStatisticsServer` builds its address as `fmt.Sprintf(":%d", port)` while `startRestServer` twenty lines above builds `fmt.Sprintf("%s:%d", apiConfig.Host, apiConfig.Port)`. That hardcoded form is what prints `[::]:9000`. The zone index is incidental; a plain IPv4 `statistics.host` is dropped the same way.

This adds `Host` to `StatisticsConfig` mirroring `ApiConfig`, and routes both servers through one small `webserverAddress(host, port)` helper.

On the default: `Api.Host` defaults to `127.0.0.1`, but the statistics server has always bound every interface, and a Prometheus scraper on another host relies on that. Defaulting `Statistics.Host` to `127.0.0.1` would break those setups on upgrade, so it defaults to the empty string instead. `webserverAddress("", 9000)` is `:9000`, which is byte for byte the current behaviour, and an operator who sets a host now gets it honoured. No existing config changes meaning.

`internal/webservers_test.go` is new; it covers the empty, IPv4, bracketed-IPv6 and zone-index forms plus the REST address, and asserts that `StatisticsConfig` now unmarshals a `host` key.

One note on verification: I could not build the full `internal` package locally because `gosensors` needs `sensors/sensors.h`, so `go build ./...` fails on macOS for reasons unrelated to this change. `go test ./internal/configuration` passes, `go vet ./internal/configuration` is clean, `gofmt` reports nothing on the touched files, and I ran the new tests against the real `viper` and `testify` dependencies in an isolated module to confirm they compile and pass. Worth a CI run on Linux to confirm the whole package links.

Closes #507
