### PR TITLE
fix: honor FanResponseDelay in PWM readback verification; restore fan state after failed or interrupted CLI init

### DIFF
--- a/cmd/fan/init.go
+++ b/cmd/fan/init.go
@@ -1,6 +1,11 @@
 package fan
 
 import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/markusressel/fan2go/internal"
 	"github.com/markusressel/fan2go/internal/configuration"
 	"github.com/markusressel/fan2go/internal/control_loop"
@@ -56,7 +61,10 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		_, err = fanController.RunInitialization()
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+
+		_, err = fanController.RunInitialization(ctx)
 		if err == nil {
 			ui.Success("Done!")
 			// print measured fan curve

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -46,6 +46,9 @@ type FanController interface {
 
 	// UpdateCurve dynamically updates the curve reference
 	UpdateCurve(curve curves.SpeedCurve)
+
+	// RunInitialization runs the fan initialization sequence.
+	RunInitialization(ctx context.Context) (map[int]float64, error)
 }
 
 type FanStateSnapshot struct {
@@ -231,7 +234,7 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 	// wait a bit to gather monitoring data
 	time.Sleep(2*time.Second + configuration.CurrentConfig.TempSensorPollingRate)
 
-	fanPwmData, err := f.runInitializationIfNeeded()
+	fanPwmData, err := f.runInitializationIfNeeded(ctx)
 	if err != nil {
 		return err
 	}
@@ -344,7 +347,7 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 	return err
 }
 
-func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, error) {
+func (f *DefaultFanController) runInitializationIfNeeded(ctx context.Context) (map[int]float64, error) {
 	fan := f.fan
 	// check if we have data for this fan in persistence,
 	// if not we need to run the initialization sequence
@@ -354,7 +357,7 @@ func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, err
 		config := fan.GetConfig()
 		if config.HwMon != nil || config.Nvidia != nil {
 			ui.Warning("Fan '%s' has not yet been analyzed, starting initialization sequence...", fan.GetId())
-			fanCurveData, err := f.RunInitialization()
+			fanCurveData, err := f.RunInitialization(ctx)
 			if err != nil {
 				return nil, err
 			}
@@ -368,25 +371,32 @@ func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, err
 	return fanRpmData, err
 }
 
-func (f *DefaultFanController) RunInitialization() (map[int]float64, error) {
-	fan := f.fan
-
-	// the `fan init` CLI command calls this directly (without Run()), so the original fan state may not have been captured yet
+func (f *DefaultFanController) RunInitialization(ctx context.Context) (map[int]float64, error) {
 	err := f.storeCurrentFanState()
 	if err != nil {
 		return nil, err
 	}
 
-	err = f.computeFanSpecificMappings()
+	curveData, err := f.runInitialization(ctx)
+	if err != nil {
+		f.restoreControlMode()
+		return nil, err
+	}
+	return curveData, nil
+}
+
+func (f *DefaultFanController) runInitialization(ctx context.Context) (map[int]float64, error) {
+	fan := f.fan
+
+	err := f.computeFanSpecificMappings()
 	if err != nil {
 		ui.Error("Fan %s: Error computing fan specific mappings: %v", fan.GetId(), err)
 		return nil, err
 	}
 
 	fanAnalyzer := NewFanCurveAnalyzer(f)
-	curveData, err := fanAnalyzer.RunInitializationSequence()
+	curveData, err := fanAnalyzer.RunInitializationSequence(ctx)
 	if err != nil {
-		f.restoreControlMode()
 		return nil, err
 	}
 
@@ -407,7 +417,6 @@ func (f *DefaultFanController) RunInitialization() (map[int]float64, error) {
 
 	fanRpmData, err := f.persistence.LoadFanRpmData(fan)
 	if err != nil {
-		f.restoreControlMode()
 		return nil, err
 	}
 

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -188,11 +188,9 @@ func (f *DefaultFanController) prepareController() (err error) {
 	return err
 }
 
+// storeCurrentFanState captures the current fan control mode and PWM value,
+// overwriting any previously saved snapshot in originalFanState.
 func (f *DefaultFanController) storeCurrentFanState() error {
-	if f.originalFanState != nil {
-		return nil
-	}
-
 	fan := f.fan
 	// store original pwm value
 	pwm, err := f.getPwm()
@@ -215,6 +213,20 @@ func (f *DefaultFanController) storeCurrentFanState() error {
 	return nil
 }
 
+// storeInitialFanState stores the initial fan state snapshot if it hasn't been captured yet.
+// Subsequent calls are no-ops to preserve the state before any controller actions.
+func (f *DefaultFanController) storeInitialFanState() error {
+	if f.originalFanState != nil {
+		return nil
+	}
+	return f.storeCurrentFanState()
+}
+
+// clearInitialFanState resets the captured initial fan state snapshot.
+func (f *DefaultFanController) clearInitialFanState() {
+	f.originalFanState = nil
+}
+
 func (f *DefaultFanController) Run(ctx context.Context) error {
 	// prepare the controller by initializing persistence and checking the fan
 	err := f.prepareController()
@@ -223,7 +235,7 @@ func (f *DefaultFanController) Run(ctx context.Context) error {
 	}
 
 	// store the current fan state to restore it when stopping the controller
-	err = f.storeCurrentFanState()
+	err = f.storeInitialFanState()
 	if err != nil {
 		return err
 	}
@@ -372,7 +384,7 @@ func (f *DefaultFanController) runInitializationIfNeeded(ctx context.Context) (m
 }
 
 func (f *DefaultFanController) RunInitialization(ctx context.Context) (map[int]float64, error) {
-	err := f.storeCurrentFanState()
+	err := f.storeInitialFanState()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -48,6 +48,14 @@ type FanController interface {
 	UpdateCurve(curve curves.SpeedCurve)
 }
 
+type FanStateSnapshot struct {
+	// the ControlMode the fan was in before the controller started
+	ControlMode fans.ControlMode
+	// the raw pwm value read from the fan before the controller started
+	// Note: this is the raw value, no pwmMap is applied to it
+	PwmValue int
+}
+
 type DefaultFanController struct {
 	// protects concurrent access to curve
 	curveMutex sync.RWMutex
@@ -61,11 +69,8 @@ type DefaultFanController struct {
 	curve curves.SpeedCurve
 	// rate to update the target fan speed
 	updateRate time.Duration
-	// the original ControlMode state of the fan before starting the controller
-	originalControlMode fans.ControlMode
-	// the original pwm value of the fan before starting the controller
-	// Note: this is the raw value read from the fan, no pwmMap is applied to it
-	originalPwmValue int
+	// the fan state as it was before the controller started (nil until captured)
+	originalFanState *FanStateSnapshot
 	// the last pwm value that was set to the fan, **before** applying the pwmMap to it
 	lastTarget *int
 	// a list of all pre-pwmMap pwm values where setPwm(x) != setPwm(y) for the controlled fan
@@ -181,13 +186,19 @@ func (f *DefaultFanController) prepareController() (err error) {
 }
 
 func (f *DefaultFanController) storeCurrentFanState() error {
+	if f.originalFanState != nil {
+		return nil
+	}
+
 	fan := f.fan
 	// store original pwm value
 	pwm, err := f.getPwm()
 	if err != nil {
 		ui.Warning("Cannot read pwm value of %s", fan.GetId())
 	}
-	f.originalPwmValue = pwm
+	snapshot := FanStateSnapshot{
+		PwmValue: pwm,
+	}
 
 	// store original pwm_enable value
 	if f.fan.Supports(fans.FeatureControlModeRead) {
@@ -195,8 +206,9 @@ func (f *DefaultFanController) storeCurrentFanState() error {
 		if err != nil {
 			ui.Warning("Cannot read pwm_enable value of %s", fan.GetId())
 		}
-		f.originalControlMode = controlMode
+		snapshot.ControlMode = controlMode
 	}
+	f.originalFanState = &snapshot
 	return nil
 }
 
@@ -359,7 +371,13 @@ func (f *DefaultFanController) runInitializationIfNeeded() (map[int]float64, err
 func (f *DefaultFanController) RunInitialization() (map[int]float64, error) {
 	fan := f.fan
 
-	err := f.computeFanSpecificMappings()
+	// the `fan init` CLI command calls this directly (without Run()), so the original fan state may not have been captured yet
+	err := f.storeCurrentFanState()
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.computeFanSpecificMappings()
 	if err != nil {
 		ui.Error("Fan %s: Error computing fan specific mappings: %v", fan.GetId(), err)
 		return nil, err
@@ -582,6 +600,13 @@ func trySetManualPwm(fan fans.Fan) error {
 }
 
 func (f *DefaultFanController) restoreControlMode() {
+	if f.originalFanState == nil {
+		ui.Warning("Skipping fan settings restore for %s, original state was never captured", f.fan.GetId())
+		return
+	}
+	originalControlMode := f.originalFanState.ControlMode
+	originalPwmValue := f.originalFanState.PwmValue
+
 	ui.Info("Trying to restore fan settings for %s...", f.fan.GetId())
 
 	var onExit *configuration.OnExitConfig
@@ -602,7 +627,7 @@ func (f *DefaultFanController) restoreControlMode() {
 	if onExit != nil {
 		// determine control mode to set on exit, if any
 		if onExit.Restore != nil {
-			controlModeToSet = &f.originalControlMode
+			controlModeToSet = &originalControlMode
 		} else if onExit.ControlMode != nil {
 			parsedControlMode, err := parseControlModeValue(*onExit.ControlMode)
 			if err != nil {
@@ -612,8 +637,8 @@ func (f *DefaultFanController) restoreControlMode() {
 			}
 		} else {
 			// if no explicit control mode to set is provided, but the fan supports writing the control mode and the original mode was not automatic, restore the original mode
-			if f.originalControlMode != fans.ControlModeAutomatic {
-				controlModeToSet = &f.originalControlMode
+			if originalControlMode != fans.ControlModeAutomatic {
+				controlModeToSet = &originalControlMode
 			}
 		}
 
@@ -623,14 +648,13 @@ func (f *DefaultFanController) restoreControlMode() {
 		}
 	} else {
 		// default restore behavior
-		controlModeToSet = &f.originalControlMode
+		controlModeToSet = &originalControlMode
 	}
 
 	if pwmToSet == nil {
 		// if the original control mode was manual, restore it to manual and set the original PWM value
 		if controlModeToSet != nil && *controlModeToSet != fans.ControlModeAutomatic {
 			// if control mode is set to manual but no speed is provided, set the original value
-			originalPwmValue := f.originalPwmValue
 			pwmToSet = &originalPwmValue
 		}
 	}

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -2121,13 +2121,57 @@ func TestRunInitialization_FailedInit_RestoresOriginalControlMode(t *testing.T) 
 		updateRate:  time.Duration(100),
 	}
 
-	_, err := controller.RunInitialization()
+	_, err := controller.RunInitialization(context.Background())
 
 	assert.Error(t, err)
 	assert.NotContains(t, fan.controlModeHistory, fans.ControlModeDisabled,
 		"the zero value of ControlMode must never be written to the fan")
 	assert.Equal(t, fans.ControlModeAutomatic, fan.ControlMode,
 		"failed init must restore the original (automatic) control mode")
+}
+
+func TestRunInitialization_Cancelled_RestoresOriginalControlMode(t *testing.T) {
+	originalConfig := configuration.CurrentConfig
+	defer func() {
+		configuration.CurrentConfig = originalConfig
+	}()
+	configuration.CurrentConfig.FanController.PwmSetDelay = 1 * time.Millisecond
+	// non-zero so the cancelled context is the only ready channel in sleepWithContext
+	configuration.CurrentConfig.FanResponseDelay = 1
+	configuration.CurrentConfig.Analysis.SampleCount = 1
+	configuration.CurrentConfig.Analysis.SampleDelay = 0
+	configuration.CurrentConfig.Analysis.SettleTimeout = 0
+
+	fan := &mockFanForFailedInit{
+		MockFan: MockFan{
+			ID:          "fan",
+			RPM:         0,
+			ControlMode: fans.ControlModeAutomatic,
+			PwmMap:      &configuration.PwmMapConfig{Identity: &configuration.PwmMapIdentityConfig{}},
+			SetPwmToGetPwmMap: &configuration.SetPwmToGetPwmMapConfig{
+				Identity: &configuration.SetPwmToGetPwmMapIdentityConfig{},
+			},
+			ControlModeConfig: &configuration.ControlModeConfig{
+				OnExit: &configuration.OnExitConfig{Restore: &configuration.OnExitRestoreConfig{}},
+			},
+		},
+	}
+	controller := DefaultFanController{
+		persistence: mockPersistence{hasPwmMap: false},
+		fan:         fan,
+		updateRate:  time.Duration(100),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := controller.RunInitialization(ctx)
+
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.NotContains(t, fan.controlModeHistory, fans.ControlModeDisabled,
+		"the zero value of ControlMode must never be written to the fan")
+	assert.Equal(t, fans.ControlModeAutomatic, fan.ControlMode,
+		"cancelled init must restore the original (automatic) control mode")
 }
 
 // --- setPwmToGetPwmMap / pwmMap edge-case tests ---

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -1917,9 +1917,11 @@ func TestRestoreControlMode_Default_RestoresOriginal(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    100,
-		originalControlMode: fans.ControlModeAutomatic,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModeAutomatic,
+		},
 	}
 
 	controller.restoreControlMode()
@@ -1940,9 +1942,11 @@ func TestRestoreControlMode_None_SkipsRestore(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    100,
-		originalControlMode: fans.ControlModeAutomatic,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModeAutomatic,
+		},
 	}
 
 	controller.restoreControlMode()
@@ -1965,9 +1969,11 @@ func TestRestoreControlMode_ExplicitControlMode(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    100,
-		originalControlMode: fans.ControlModePWM,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModePWM,
+		},
 	}
 
 	controller.restoreControlMode()
@@ -1990,9 +1996,11 @@ func TestRestoreControlMode_ExplicitSpeed(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    100,
-		originalControlMode: fans.ControlModePWM,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModePWM,
+		},
 	}
 
 	controller.restoreControlMode()
@@ -2016,9 +2024,11 @@ func TestRestoreControlMode_ExplicitControlModeAndSpeed(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    100,
-		originalControlMode: fans.ControlModePWM,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModePWM,
+		},
 	}
 
 	controller.restoreControlMode()
@@ -2040,15 +2050,84 @@ func TestRestoreControlMode_Restore_Explicit(t *testing.T) {
 		supportsControlMode: true,
 	}
 	controller := DefaultFanController{
-		fan:                 fan,
-		originalPwmValue:    75,
-		originalControlMode: fans.ControlModeAutomatic,
+		fan: fan,
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    75,
+			ControlMode: fans.ControlModeAutomatic,
+		},
 	}
 
 	controller.restoreControlMode()
 
 	assert.Empty(t, fan.pwmHistory)
 	assert.Contains(t, fan.controlModeHistory, fans.ControlModeAutomatic)
+}
+
+func TestRestoreControlMode_StateNeverCaptured_DoesNothing(t *testing.T) {
+	fan := &mockFanForRestore{
+		MockFan:             MockFan{ID: "fan", PWM: 200},
+		supportsControlMode: true,
+	}
+	controller := DefaultFanController{
+		fan: fan,
+	}
+
+	controller.restoreControlMode()
+
+	assert.Empty(t, fan.pwmHistory)
+	assert.Empty(t, fan.controlModeHistory)
+}
+
+// mockFanForFailedInit never spins (0 RPM at any PWM value) and tracks all control mode changes.
+type mockFanForFailedInit struct {
+	MockFan
+	controlModeHistory []fans.ControlMode
+}
+
+func (f *mockFanForFailedInit) SetControlMode(mode fans.ControlMode) error {
+	f.controlModeHistory = append(f.controlModeHistory, mode)
+	f.ControlMode = mode
+	return nil
+}
+
+func TestRunInitialization_FailedInit_RestoresOriginalControlMode(t *testing.T) {
+	originalConfig := configuration.CurrentConfig
+	defer func() {
+		configuration.CurrentConfig = originalConfig
+	}()
+	configuration.CurrentConfig.FanController.PwmSetDelay = 1 * time.Millisecond
+	configuration.CurrentConfig.FanResponseDelay = 0
+	configuration.CurrentConfig.Analysis.SampleCount = 1
+	configuration.CurrentConfig.Analysis.SampleDelay = 0
+	configuration.CurrentConfig.Analysis.SettleTimeout = 0
+
+	fan := &mockFanForFailedInit{
+		MockFan: MockFan{
+			ID:          "fan",
+			RPM:         0,
+			ControlMode: fans.ControlModeAutomatic,
+			PwmMap:      &configuration.PwmMapConfig{Identity: &configuration.PwmMapIdentityConfig{}},
+			SetPwmToGetPwmMap: &configuration.SetPwmToGetPwmMapConfig{
+				Identity: &configuration.SetPwmToGetPwmMapIdentityConfig{},
+			},
+			ControlModeConfig: &configuration.ControlModeConfig{
+				OnExit: &configuration.OnExitConfig{Restore: &configuration.OnExitRestoreConfig{}},
+			},
+		},
+	}
+	controller := DefaultFanController{
+		persistence: mockPersistence{hasPwmMap: false},
+		fan:         fan,
+		updateRate:  time.Duration(100),
+	}
+
+	_, err := controller.RunInitialization()
+
+	assert.Error(t, err)
+	assert.NotContains(t, fan.controlModeHistory, fans.ControlModeDisabled,
+		"the zero value of ControlMode must never be written to the fan")
+	assert.Equal(t, fans.ControlModeAutomatic, fan.ControlMode,
+		"failed init must restore the original (automatic) control mode")
 }
 
 // --- setPwmToGetPwmMap / pwmMap edge-case tests ---

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -2350,3 +2350,68 @@ func TestGetPwmSetDelay_FallsBackToGlobal(t *testing.T) {
 	// THEN
 	assert.Equal(t, globalDelay, result)
 }
+
+func TestStoreInitialFanState_OnlyCapturesOnce(t *testing.T) {
+	fan := &mockFanForRestore{
+		MockFan: MockFan{
+			ID:          "fan",
+			PWM:         100,
+			ControlMode: fans.ControlModePWM,
+		},
+		supportsControlMode: true,
+	}
+	controller := DefaultFanController{
+		fan: fan,
+	}
+
+	err := controller.storeInitialFanState()
+	assert.NoError(t, err)
+	assert.NotNil(t, controller.originalFanState)
+	assert.Equal(t, 100, controller.originalFanState.PwmValue)
+
+	// Change fan PWM to 200
+	fan.PWM = 200
+
+	// Subsequent storeInitialFanState call should not overwrite existing snapshot
+	err = controller.storeInitialFanState()
+	assert.NoError(t, err)
+	assert.Equal(t, 100, controller.originalFanState.PwmValue)
+}
+
+func TestStoreCurrentFanState_OverwritesSnapshot(t *testing.T) {
+	fan := &mockFanForRestore{
+		MockFan: MockFan{
+			ID:          "fan",
+			PWM:         100,
+			ControlMode: fans.ControlModePWM,
+		},
+		supportsControlMode: true,
+	}
+	controller := DefaultFanController{
+		fan: fan,
+	}
+
+	err := controller.storeInitialFanState()
+	assert.NoError(t, err)
+	assert.Equal(t, 100, controller.originalFanState.PwmValue)
+
+	// Change fan PWM to 200
+	fan.PWM = 200
+
+	// storeCurrentFanState should overwrite snapshot with new value
+	err = controller.storeCurrentFanState()
+	assert.NoError(t, err)
+	assert.Equal(t, 200, controller.originalFanState.PwmValue)
+}
+
+func TestClearInitialFanState_ResetsSnapshot(t *testing.T) {
+	controller := DefaultFanController{
+		originalFanState: &FanStateSnapshot{
+			PwmValue:    100,
+			ControlMode: fans.ControlModePWM,
+		},
+	}
+
+	controller.clearInitialFanState()
+	assert.Nil(t, controller.originalFanState)
+}

--- a/internal/controller/fan_analysis.go
+++ b/internal/controller/fan_analysis.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -14,6 +15,15 @@ import (
 
 const pwmMismatchRetries = 2
 
+func sleepWithContext(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
 type FanCurveAnalyzer struct {
 	fanController *DefaultFanController
 }
@@ -26,7 +36,7 @@ func NewFanCurveAnalyzer(
 	}
 }
 
-func (f *FanCurveAnalyzer) RunInitializationSequence() (rpmCurve map[int]float64, err error) {
+func (f *FanCurveAnalyzer) RunInitializationSequence(ctx context.Context) (rpmCurve map[int]float64, err error) {
 	fan := f.fanController.fan
 
 	if !fan.Supports(fans.FeatureRpmSensor) {
@@ -51,21 +61,21 @@ func (f *FanCurveAnalyzer) RunInitializationSequence() (rpmCurve map[int]float64
 	initStarted := time.Now()
 
 	startBoundaryStarted := time.Now()
-	startIdx, _, err := f.detectStartBoundary(fan, distinct, curveData)
+	startIdx, _, err := f.detectStartBoundary(ctx, fan, distinct, curveData)
 	if err != nil {
 		return nil, err
 	}
 	ui.Info("Fan %s: Boundary discovery (start) finished in %s", fan.GetId(), time.Since(startBoundaryStarted).Round(time.Millisecond))
 
 	maxBoundaryStarted := time.Now()
-	maxIdx, _, err := f.detectMaxBoundary(fan, distinct, startIdx, curveData)
+	maxIdx, _, err := f.detectMaxBoundary(ctx, fan, distinct, startIdx, curveData)
 	if err != nil {
 		return nil, err
 	}
 	ui.Info("Fan %s: Boundary discovery (max) finished in %s", fan.GetId(), time.Since(maxBoundaryStarted).Round(time.Millisecond))
 
 	interiorStarted := time.Now()
-	curveData, err = f.sampleInteriorCoarse(fan, distinct, startIdx, maxIdx, curveData)
+	curveData, err = f.sampleInteriorCoarse(ctx, fan, distinct, startIdx, maxIdx, curveData)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +92,7 @@ func (f *FanCurveAnalyzer) RunInitializationSequence() (rpmCurve map[int]float64
 }
 
 func (f *FanCurveAnalyzer) detectStartBoundary(
+	ctx context.Context,
 	fan fans.Fan,
 	distinct []int,
 	curveData map[int]float64,
@@ -95,7 +106,7 @@ func (f *FanCurveAnalyzer) detectStartBoundary(
 	for low <= high {
 		mid := (low + high) / 2
 		pwm := distinct[mid]
-		rpm, measureErr := f.measureAtPwm(fan, pwm, configuration.CurrentConfig.Analysis.SettleTimeout)
+		rpm, measureErr := f.measureAtPwm(ctx, fan, pwm, configuration.CurrentConfig.Analysis.SettleTimeout)
 		if measureErr != nil {
 			return 0, 0, measureErr
 		}
@@ -134,6 +145,7 @@ func (f *FanCurveAnalyzer) detectStartBoundary(
 }
 
 func (f *FanCurveAnalyzer) detectMaxBoundary(
+	ctx context.Context,
 	fan fans.Fan,
 	distinct []int,
 	startIdx int,
@@ -162,7 +174,7 @@ func (f *FanCurveAnalyzer) detectMaxBoundary(
 	ui.Info("Fan %s: Discovering max boundary...", fan.GetId())
 	for idx := lastIdx; idx >= topStartIdx; idx -= step {
 		pwm := distinct[idx]
-		rpm, measureErr := f.measureAtPwm(fan, pwm, 0)
+		rpm, measureErr := f.measureAtPwm(ctx, fan, pwm, 0)
 		if measureErr != nil {
 			return 0, 0, measureErr
 		}
@@ -186,7 +198,7 @@ func (f *FanCurveAnalyzer) detectMaxBoundary(
 		pwm := distinct[idx]
 		rpm, exists := fastScan[pwm]
 		if !exists {
-			measureRpm, measureErr := f.measureAtPwm(fan, pwm, 0)
+			measureRpm, measureErr := f.measureAtPwm(ctx, fan, pwm, 0)
 			if measureErr != nil {
 				return 0, 0, measureErr
 			}
@@ -204,7 +216,7 @@ func (f *FanCurveAnalyzer) detectMaxBoundary(
 	}
 
 	if roughIdx >= 0 {
-		confirmedIdx, confirmedPwm, confirmErr := f.confirmMaxBoundary(fan, distinct, startIdx, roughIdx, curveData)
+		confirmedIdx, confirmedPwm, confirmErr := f.confirmMaxBoundary(ctx, fan, distinct, startIdx, roughIdx, curveData)
 		if confirmErr != nil {
 			return 0, 0, confirmErr
 		}
@@ -219,6 +231,7 @@ func (f *FanCurveAnalyzer) detectMaxBoundary(
 }
 
 func (f *FanCurveAnalyzer) confirmMaxBoundary(
+	ctx context.Context,
 	fan fans.Fan,
 	distinct []int,
 	startIdx int,
@@ -246,7 +259,7 @@ func (f *FanCurveAnalyzer) confirmMaxBoundary(
 	peakConfirmed := 0.0
 	for _, idx := range confirmIndices {
 		pwm := distinct[idx]
-		rpm, measureErr := f.measureAtPwm(fan, pwm, configuration.CurrentConfig.Analysis.SettleTimeout)
+		rpm, measureErr := f.measureAtPwm(ctx, fan, pwm, configuration.CurrentConfig.Analysis.SettleTimeout)
 		if measureErr != nil {
 			return 0, 0, measureErr
 		}
@@ -284,6 +297,7 @@ func (f *FanCurveAnalyzer) confirmMaxBoundary(
 }
 
 func (f *FanCurveAnalyzer) sampleInteriorCoarse(
+	ctx context.Context,
 	fan fans.Fan,
 	distinct []int,
 	startIdx int,
@@ -308,7 +322,7 @@ func (f *FanCurveAnalyzer) sampleInteriorCoarse(
 			continue
 		}
 		settleTimeout := settleTimeoutForPwmJump(lastMeasuredPwm, pwm, configuration.CurrentConfig.Analysis.SettleTimeout)
-		rpm, err := f.measureAtPwm(fan, pwm, settleTimeout)
+		rpm, err := f.measureAtPwm(ctx, fan, pwm, settleTimeout)
 		if err != nil {
 			return curveData, err
 		}
@@ -394,13 +408,15 @@ func (f *FanCurveAnalyzer) rpmCurveMeasurementCleanup(curveData map[int]float64)
 // expected value after setting it even after waiting FanResponseDelay (indicates the hardware ignored the request).
 // If settleTimeout > 0, waitForFanToSettle is called with that timeout (used for large PWM steps).
 // If settleTimeout == 0, a plain FanResponseDelay sleep is used instead (sufficient for small steps).
-func (f *FanCurveAnalyzer) measureAtPwm(fan fans.Fan, pwm int, settleTimeout time.Duration) (float64, error) {
+func (f *FanCurveAnalyzer) measureAtPwm(ctx context.Context, fan fans.Fan, pwm int, settleTimeout time.Duration) (float64, error) {
 	actualPwm := f.fanController.applyPwmMapToTarget(pwm)
 	matchedPwm := false
 	for attempt := 0; attempt <= pwmMismatchRetries; attempt++ {
 		if attempt > 0 {
 			// The reported PWM may lag behind the requested value on some hardware, so wait FanResponseDelay before retrying.
-			time.Sleep(time.Duration(configuration.CurrentConfig.FanResponseDelay) * time.Second)
+			if err := sleepWithContext(ctx, time.Duration(configuration.CurrentConfig.FanResponseDelay)*time.Second); err != nil {
+				return 0, err
+			}
 		}
 		err := f.fanController.setPwm(actualPwm)
 		if err != nil {
@@ -427,10 +443,14 @@ func (f *FanCurveAnalyzer) measureAtPwm(fan fans.Fan, pwm int, settleTimeout tim
 	}
 
 	if settleTimeout > 0 {
-		f.waitForFanToSettle(fan, settleTimeout)
+		if err := f.waitForFanToSettle(ctx, fan, settleTimeout); err != nil {
+			return 0, err
+		}
 	} else {
 		// Small PWM step — a response-delay sleep is sufficient.
-		time.Sleep(time.Duration(configuration.CurrentConfig.FanResponseDelay) * time.Second)
+		if err := sleepWithContext(ctx, time.Duration(configuration.CurrentConfig.FanResponseDelay)*time.Second); err != nil {
+			return 0, err
+		}
 	}
 
 	sampleCount := configuration.CurrentConfig.Analysis.SampleCount
@@ -441,7 +461,9 @@ func (f *FanCurveAnalyzer) measureAtPwm(fan fans.Fan, pwm int, settleTimeout tim
 	samples := make([]float64, 0, sampleCount)
 	for i := 0; i < sampleCount; i++ {
 		if i > 0 {
-			time.Sleep(sampleDelay)
+			if err := sleepWithContext(ctx, sampleDelay); err != nil {
+				return 0, err
+			}
 		}
 		r, err := fan.GetRpm()
 		if err != nil {
@@ -459,7 +481,7 @@ func (f *FanCurveAnalyzer) measureAtPwm(fan fans.Fan, pwm int, settleTimeout tim
 // waitForFanToSettle waits until the fan's RPM readings are stable (requiredConsecutive consecutive
 // readings with diff <= MaxRpmDiffForSettledFan). If timeout > 0 and the deadline is exceeded, a
 // warning is logged and the function returns early rather than blocking forever.
-func (f *FanCurveAnalyzer) waitForFanToSettle(fan fans.Fan, timeout time.Duration) {
+func (f *FanCurveAnalyzer) waitForFanToSettle(ctx context.Context, fan fans.Fan, timeout time.Duration) error {
 	const requiredConsecutive = 3
 	const settleSampleInterval = 500 * time.Millisecond
 	const settleWindowSize = 8
@@ -484,9 +506,11 @@ func (f *FanCurveAnalyzer) waitForFanToSettle(fan fans.Fan, timeout time.Duratio
 	for consecutiveStable < requiredConsecutive {
 		if timeout > 0 && time.Now().After(deadline) {
 			ui.Warning("Fan %s did not settle within %v, continuing anyway (%d/%d stable readings)", fan.GetId(), timeout, consecutiveStable, requiredConsecutive)
-			return
+			return nil
 		}
-		time.Sleep(settleSampleInterval)
+		if err := sleepWithContext(ctx, settleSampleInterval); err != nil {
+			return err
+		}
 
 		currentRpm, err := fan.GetRpm()
 		if err != nil {
@@ -519,6 +543,7 @@ func (f *FanCurveAnalyzer) waitForFanToSettle(fan fans.Fan, timeout time.Duratio
 			fan.GetId(), consecutiveStable, requiredConsecutive, meanNow, rangeNow)
 	}
 	ui.Debug("Fan %s has settled (%d consecutive stable readings)", fan.GetId(), requiredConsecutive)
+	return nil
 }
 
 func evaluateAdaptiveSettling(window []float64, prevMean *float64, prevRange *float64, baseThreshold float64) (bool, float64, float64) {

--- a/internal/controller/fan_analysis.go
+++ b/internal/controller/fan_analysis.go
@@ -391,13 +391,17 @@ func (f *FanCurveAnalyzer) rpmCurveMeasurementCleanup(curveData map[int]float64)
 // measureAtPwm sets the fan to the given target PWM value, optionally waits for it to settle,
 // takes SampleCount RPM samples spaced SampleDelay apart, and returns
 // their median as a robust per-point estimate. Returns -1 (with nil error) if the reported PWM does not match the
-// expected value after setting it (indicates the hardware ignored the request).
+// expected value after setting it even after waiting FanResponseDelay (indicates the hardware ignored the request).
 // If settleTimeout > 0, waitForFanToSettle is called with that timeout (used for large PWM steps).
 // If settleTimeout == 0, a plain FanResponseDelay sleep is used instead (sufficient for small steps).
 func (f *FanCurveAnalyzer) measureAtPwm(fan fans.Fan, pwm int, settleTimeout time.Duration) (float64, error) {
 	actualPwm := f.fanController.applyPwmMapToTarget(pwm)
 	matchedPwm := false
 	for attempt := 0; attempt <= pwmMismatchRetries; attempt++ {
+		if attempt > 0 {
+			// The reported PWM may lag behind the requested value on some hardware, so wait FanResponseDelay before retrying.
+			time.Sleep(time.Duration(configuration.CurrentConfig.FanResponseDelay) * time.Second)
+		}
 		err := f.fanController.setPwm(actualPwm)
 		if err != nil {
 			return 0, fmt.Errorf("unable to set PWM %d: %w", actualPwm, err)

--- a/internal/controller/fan_analysis_measure_test.go
+++ b/internal/controller/fan_analysis_measure_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/markusressel/fan2go/internal/configuration"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockFanLaggingPwmReadback is a fan whose reported PWM converges to the requested value only after lag has passed.
+type mockFanLaggingPwmReadback struct {
+	MockFan
+	lag          time.Duration
+	targetPwm    int
+	reportedPwm  int
+	lastChangeAt time.Time
+}
+
+func (fan *mockFanLaggingPwmReadback) SetPwm(pwm int) error {
+	if pwm != fan.targetPwm {
+		fan.reportedPwm = fan.targetPwm
+		fan.targetPwm = pwm
+		fan.lastChangeAt = time.Now()
+	}
+	return nil
+}
+
+func (fan *mockFanLaggingPwmReadback) GetPwm() (int, error) {
+	if time.Since(fan.lastChangeAt) >= fan.lag {
+		return fan.targetPwm, nil
+	}
+	return fan.reportedPwm, nil
+}
+
+func TestMeasureAtPwm_LaggingReadback_HonorsFanResponseDelay(t *testing.T) {
+	// GIVEN
+	originalConfig := configuration.CurrentConfig
+	defer func() {
+		configuration.CurrentConfig = originalConfig
+	}()
+	configuration.CurrentConfig.FanController.PwmSetDelay = 1 * time.Millisecond
+	configuration.CurrentConfig.FanResponseDelay = 1
+	configuration.CurrentConfig.Analysis.SampleCount = 1
+	configuration.CurrentConfig.Analysis.SampleDelay = 0
+
+	fan := &mockFanLaggingPwmReadback{
+		MockFan: MockFan{
+			ID:  "fan",
+			RPM: 900,
+		},
+		lag: 300 * time.Millisecond,
+	}
+	controller := &DefaultFanController{
+		fan: fan,
+	}
+	for i := 0; i < 256; i++ {
+		controller.pwmMapping[i] = i
+	}
+	analyzer := NewFanCurveAnalyzer(controller)
+
+	// WHEN
+	rpm, err := analyzer.measureAtPwm(fan, 128, 0)
+
+	// THEN: after FanResponseDelay the reported PWM converges and the RPM is measured
+	assert.NoError(t, err)
+	assert.Equal(t, 900.0, rpm, "measureAtPwm should wait FanResponseDelay for the reported PWM to converge instead of skipping the sample")
+}

--- a/internal/controller/fan_analysis_measure_test.go
+++ b/internal/controller/fan_analysis_measure_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -60,7 +61,7 @@ func TestMeasureAtPwm_LaggingReadback_HonorsFanResponseDelay(t *testing.T) {
 	analyzer := NewFanCurveAnalyzer(controller)
 
 	// WHEN
-	rpm, err := analyzer.measureAtPwm(fan, 128, 0)
+	rpm, err := analyzer.measureAtPwm(context.Background(), fan, 128, 0)
 
 	// THEN: after FanResponseDelay the reported PWM converges and the RPM is measured
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #511.

Since 0.14.0 the two-phase adaptive sweep verifies the PWM readback before sampling RPM, but re-checks after only `PwmSetDelay` (5 ms by default). On hardware where the reported PWM converges slowly towards the requested value (the NCT6687 EC ramps DC outputs gradually; the nct6687d driver serves cached sysfs reads) the check can never pass, so every sample is skipped as a mismatch and boundary discovery fails in under a second with "unable to detect start boundary, no spinning PWM found" while the fans are audibly spinning. Full logs and analysis in the issue.

Three small fixes, one commit each:

- `measureAtPwm()` now waits `FanResponseDelay` before each mismatch retry.
- `RunInitialization()` captures the original fan state, so a failed init started from the CLI (which does not go through `Run()`) restores the previous control mode instead of applying the zero value of `ControlMode`. That zero value (disabled) was rejected by the driver, and the `SetControlMode` error fallback then left the fan in manual mode at PWM 255. `restoreControlMode()` also skips the restore when no state was ever captured.
- `fan init` handles SIGINT/SIGTERM and restores the fan state when interrupted.

Verified on the affected hardware (MSI MPG B650 Carbon, NCT6687, three DC-controlled case fans): `fan init` completes in ~4 min per fan with real settle pauses and a full RPM curve, manual `minPwm`/`startPwm`/`maxPwm` are honored, and both Ctrl-C during init and daemon shutdown hand the channels back to the EC (`pwm_enable` returns to 2). Regression tests included for all three fixes.
