### PR TITLE
feat: Warn on unknown config keys and suggest corrections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/md14454/gosensors v0.0.0-20180726083412-bded752ab001
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/natefinch/atomic v1.0.1
 	github.com/oklog/run v1.2.0
 	github.com/orcaman/concurrent-map/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=

--- a/internal/configuration/config.go
+++ b/internal/configuration/config.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/creasty/defaults"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/markusressel/fan2go/internal/control_loop"
-	"github.com/mitchellh/mapstructure"
 
 	"github.com/markusressel/fan2go/internal/ui"
 	"github.com/mitchellh/go-homedir"
@@ -152,6 +152,7 @@ func LoadConfig() (Configuration, error) {
 		return cfg, err
 	}
 
+	var md mapstructure.Metadata
 	err := viper.Unmarshal(
 		&cfg,
 		viper.DecodeHook(
@@ -164,10 +165,15 @@ func LoadConfig() (Configuration, error) {
 				mapstructure.TextUnmarshallerHookFunc(),
 			),
 		),
+		func(dc *mapstructure.DecoderConfig) {
+			dc.Metadata = &md
+		},
 	)
 	if err != nil {
 		return cfg, err
 	}
+
+	WarnUnknownKeys(&cfg, md.Unused, viper.Get)
 
 	// apply default values again to set any nested struct defaults that were
 	// created after the initial parsing pass

--- a/internal/configuration/unknown_keys.go
+++ b/internal/configuration/unknown_keys.go
@@ -98,7 +98,7 @@ func getValidKeys(parentType reflect.Type) []string {
 	if parentType == nil {
 		return keys
 	}
-	for parentType.Kind() == reflect.Ptr {
+	for parentType.Kind() == reflect.Pointer {
 		parentType = parentType.Elem()
 	}
 	if parentType.Kind() != reflect.Struct {
@@ -127,7 +127,7 @@ func getValidKeys(parentType reflect.Type) []string {
 }
 
 func getParentType(path []string, currentType reflect.Type) reflect.Type {
-	for currentType.Kind() == reflect.Ptr {
+	for currentType.Kind() == reflect.Pointer {
 		currentType = currentType.Elem()
 	}
 	if len(path) == 0 {

--- a/internal/configuration/unknown_keys.go
+++ b/internal/configuration/unknown_keys.go
@@ -1,0 +1,162 @@
+package configuration
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/markusressel/fan2go/internal/ui"
+)
+
+// WarnUnknownKeys checks unused configuration keys, determines if they are sections,
+// finds suggestions for typos, and prints warnings.
+func WarnUnknownKeys(cfg interface{}, unusedKeys []string, getValue func(string) interface{}) {
+	re := regexp.MustCompile(`\[(\d+)\]`)
+	for _, unused := range unusedKeys {
+		key := strings.ToLower(unused)
+		viperKey := re.ReplaceAllString(key, ".$1")
+		val := getValue(viperKey)
+
+		isSection := false
+		if val != nil {
+			kind := reflect.TypeOf(val).Kind()
+			if kind == reflect.Map || kind == reflect.Slice {
+				isSection = true
+			}
+		}
+
+		suggestion := ""
+		pathParts := strings.Split(viperKey, ".")
+		if len(pathParts) > 0 {
+			unknownPart := pathParts[len(pathParts)-1]
+			parentPath := pathParts[:len(pathParts)-1]
+
+			parentType := getParentType(parentPath, reflect.TypeOf(cfg))
+			validKeys := getValidKeys(parentType)
+
+			closest := getClosestMatch(unknownPart, validKeys)
+			if closest != "" {
+				suggestion = fmt.Sprintf(" - did you mean '%s'?", closest)
+			}
+		}
+
+		if isSection {
+			ui.Warning("Unknown configuration section (and its contents): %s%s", key, suggestion)
+		} else {
+			ui.Warning("Unknown configuration key: %s%s", key, suggestion)
+		}
+	}
+}
+
+func levenshtein(a, b string) int {
+	d := make([][]int, len(a)+1)
+	for i := range d {
+		d[i] = make([]int, len(b)+1)
+		d[i][0] = i
+	}
+	for j := range d[0] {
+		d[0][j] = j
+	}
+	for j := 1; j <= len(b); j++ {
+		for i := 1; i <= len(a); i++ {
+			if a[i-1] == b[j-1] {
+				d[i][j] = d[i-1][j-1]
+			} else {
+				min := d[i-1][j] + 1
+				if d[i][j-1]+1 < min {
+					min = d[i][j-1] + 1
+				}
+				if d[i-1][j-1]+1 < min {
+					min = d[i-1][j-1] + 1
+				}
+				d[i][j] = min
+			}
+		}
+	}
+	return d[len(a)][len(b)]
+}
+
+func getClosestMatch(target string, options []string) string {
+	closest := ""
+	minDist := -1
+	for _, opt := range options {
+		dist := levenshtein(target, opt)
+		if minDist == -1 || dist < minDist {
+			minDist = dist
+			closest = opt
+		}
+	}
+	if minDist != -1 && minDist <= 3 && len(target) > 2 {
+		return closest
+	}
+	return ""
+}
+
+func getValidKeys(parentType reflect.Type) []string {
+	var keys []string
+	if parentType == nil {
+		return keys
+	}
+	for parentType.Kind() == reflect.Ptr {
+		parentType = parentType.Elem()
+	}
+	if parentType.Kind() != reflect.Struct {
+		return keys
+	}
+	for i := 0; i < parentType.NumField(); i++ {
+		field := parentType.Field(i)
+		if field.PkgPath != "" { // unexported
+			continue
+		}
+
+		name := ""
+		for _, tagKey := range []string{"mapstructure", "json"} {
+			tag := field.Tag.Get(tagKey)
+			if tag != "" && tag != "-" {
+				name = strings.Split(tag, ",")[0]
+				break
+			}
+		}
+		if name == "" {
+			name = strings.ToLower(field.Name)
+		}
+		keys = append(keys, name)
+	}
+	return keys
+}
+
+func getParentType(path []string, currentType reflect.Type) reflect.Type {
+	for currentType.Kind() == reflect.Ptr {
+		currentType = currentType.Elem()
+	}
+	if len(path) == 0 {
+		return currentType
+	}
+	part := path[0]
+
+	switch currentType.Kind() {
+	case reflect.Struct:
+		for i := 0; i < currentType.NumField(); i++ {
+			field := currentType.Field(i)
+			name := strings.ToLower(field.Name)
+			for _, tagKey := range []string{"mapstructure", "json"} {
+				tag := field.Tag.Get(tagKey)
+				if tag != "" && tag != "-" {
+					tagOpts := strings.Split(tag, ",")
+					if strings.ToLower(tagOpts[0]) == part {
+						name = strings.ToLower(tagOpts[0])
+						break
+					}
+				}
+			}
+			if name == part {
+				return getParentType(path[1:], field.Type)
+			}
+		}
+		return nil
+	case reflect.Slice, reflect.Array, reflect.Map:
+		return getParentType(path[1:], currentType.Elem())
+	}
+	return nil
+}

--- a/internal/configuration/unknown_keys_test.go
+++ b/internal/configuration/unknown_keys_test.go
@@ -1,0 +1,94 @@
+package configuration
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"fan", "fans", 1},
+		{"platorm", "platform", 1},
+		{"sensors", "sensor", 1},
+		{"same", "same", 0},
+	}
+
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestGetClosestMatch(t *testing.T) {
+	tests := []struct {
+		target  string
+		options []string
+		want    string
+	}{
+		{"fan", []string{"fans", "sensors"}, "fans"},
+		{"plattorm", []string{"platform", "index"}, "platform"},
+		{"xyz", []string{"platform", "index"}, ""}, // too far
+		{"ab", []string{"abc", "def"}, ""},         // too short
+	}
+
+	for _, tt := range tests {
+		if got := getClosestMatch(tt.target, tt.options); got != tt.want {
+			t.Errorf("getClosestMatch(%q, %v) = %q, want %q", tt.target, tt.options, got, tt.want)
+		}
+	}
+}
+
+func TestGetValidKeys(t *testing.T) {
+	cfg := Configuration{}
+	keys := getValidKeys(reflect.TypeOf(cfg))
+
+	expected := []string{"dbpath", "runfaninitializationinparallel", "maxrpmdiffforsettledfan", "fanresponsedelay", "tempsensorpollingrate", "temprollingwindowsize", "rpmpollingrate", "rpmrollingwindowsize", "controlleradjustmenttickrate", "analysis", "fancontroller", "fans", "sensors", "curves", "api", "statistics", "profiling"}
+
+	if len(keys) != len(expected) {
+		t.Errorf("getValidKeys() returned %d keys, want %d", len(keys), len(expected))
+	}
+
+	// simple check for some known keys
+	foundFans := false
+	for _, k := range keys {
+		if k == "fans" {
+			foundFans = true
+			break
+		}
+	}
+	if !foundFans {
+		t.Errorf("getValidKeys() missing 'fans'")
+	}
+}
+
+func TestGetParentType(t *testing.T) {
+	cfg := Configuration{}
+
+	// Root level
+	typ := getParentType([]string{}, reflect.TypeOf(cfg))
+	if typ != reflect.TypeOf(cfg) {
+		t.Errorf("getParentType() for root failed")
+	}
+
+	// Fans slice element type (FanConfig)
+	typ = getParentType([]string{"fans", "0"}, reflect.TypeOf(cfg))
+	if typ.Name() != "FanConfig" {
+		t.Errorf("getParentType() for fans.0 = %v, want FanConfig", typ)
+	}
+
+	// HwMon config inside fan
+	typ = getParentType([]string{"fans", "0", "hwmon"}, reflect.TypeOf(cfg))
+	if typ.Name() != "HwMonFanConfig" {
+		t.Errorf("getParentType() for fans.0.hwmon = %v, want HwMonFanConfig", typ)
+	}
+
+	// Invalid path
+	typ = getParentType([]string{"invalid", "path"}, reflect.TypeOf(cfg))
+	if typ != nil {
+		t.Errorf("getParentType() for invalid path should be nil, got %v", typ)
+	}
+}

--- a/internal/configuration/unknown_keys_test.go
+++ b/internal/configuration/unknown_keys_test.go
@@ -11,7 +11,7 @@ func TestLevenshtein(t *testing.T) {
 		want int
 	}{
 		{"fan", "fans", 1},
-		{"platorm", "platform", 1},
+		{"platorm", "platform", 1}, // codespell:ignore
 		{"sensors", "sensor", 1},
 		{"same", "same", 0},
 	}


### PR DESCRIPTION
# Warn on Unknown Configuration Keys

## Related Issue
Fixes #513 

## Description
This PR introduces robust configuration validation to detect and warn users about unknown keys and sections in their `fan2go.yaml` config file. Previously, if a user made a typo (such as `fan:` instead of `fans:`), the configuration would quietly ignore the section and load an empty config, making it incredibly difficult to debug.

### Changes
*   **Metadata Extraction**: Hooked into `viper.Unmarshal` to capture `mapstructure.Metadata.Unused`, effectively pinpointing all keys loaded from the configuration file that do not map to the `Configuration` struct.
*   **Dependency Update**: Migrated the `mapstructure` import in `config.go` to `github.com/go-viper/mapstructure/v2` to match Viper's internal dependencies.
*   **Context-Aware Warnings**: Extracted the logic into a new `unknown_keys.go` file. The warning system uses reflection to check if an unknown property is a simple key or a nested section (map/slice), displaying a tailored message so users know if an entire block was skipped.
*   **Typo Suggestions**: When an unknown key is found, the system parses its dot-notation path, reflects down the configuration struct to determine the valid properties for that specific nested level (reading `json` and `mapstructure` tags), and calculates a Levenshtein distance to suggest the closest valid key.
*   **Unit Tests**: Added comprehensive tests in `unknown_keys_test.go` to ensure tree traversal, valid key extraction, and Levenshtein similarity bounds work reliably.

## Examples
When a user accidentally types `fan:` instead of `fans:`:
```text
 WARNING  Unknown configuration section (and its contents): fan - did you mean 'fans'?
```

When a user misspells a deeply nested property (e.g., `platorm` instead of `platform` in `fans[0].hwmon`):
```text
 WARNING  Unknown configuration key: fans[0].hwmon.platorm - did you mean 'platform'?
```
